### PR TITLE
fix(domain): make SongEntity Parcelable to fix ANDROID-B8 + ANDROID-BD

### DIFF
--- a/domain/src/main/java/com/maxrave/domain/data/entities/SongEntity.kt
+++ b/domain/src/main/java/com/maxrave/domain/data/entities/SongEntity.kt
@@ -1,11 +1,33 @@
 package com.maxrave.domain.data.entities
 
+import android.os.Parcel
+import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.maxrave.domain.data.entities.DownloadState.STATE_NOT_DOWNLOADED
 import com.maxrave.domain.data.type.RecentlyType
 import java.time.LocalDateTime
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.WriteWith
 
+private object NullableLocalDateTimeParceler : kotlinx.parcelize.Parceler<LocalDateTime?> {
+    override fun create(parcel: Parcel): LocalDateTime? = parcel.readString()?.let { LocalDateTime.parse(it) }
+
+    override fun LocalDateTime?.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(this?.toString())
+    }
+}
+
+private object NonNullLocalDateTimeParceler : kotlinx.parcelize.Parceler<LocalDateTime> {
+    override fun create(parcel: Parcel): LocalDateTime =
+        parcel.readString()?.let { LocalDateTime.parse(it) } ?: LocalDateTime.now()
+
+    override fun LocalDateTime.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(toString())
+    }
+}
+
+@Parcelize
 @Entity(tableName = "song")
 data class SongEntity(
     @PrimaryKey(autoGenerate = false) val videoId: String = "",
@@ -26,11 +48,12 @@ data class SongEntity(
     val liked: Boolean = false,
     val totalPlayTime: Long = 0,
     val downloadState: Int = STATE_NOT_DOWNLOADED,
-    val favoriteAt: LocalDateTime? = LocalDateTime.now(),
-    val downloadedAt: LocalDateTime? = LocalDateTime.now(),
-    val inLibrary: LocalDateTime = LocalDateTime.now(),
+    val favoriteAt: @WriteWith<NullableLocalDateTimeParceler> LocalDateTime? = LocalDateTime.now(),
+    val downloadedAt: @WriteWith<NullableLocalDateTimeParceler> LocalDateTime? = LocalDateTime.now(),
+    val inLibrary: @WriteWith<NonNullLocalDateTimeParceler> LocalDateTime = LocalDateTime.now(),
     val canvasUrl: String? = null,
     val canvasThumbUrl: String? = null,
-) : RecentlyType {
+) : RecentlyType,
+    Parcelable {
     override fun objectType(): RecentlyType.Type = RecentlyType.Type.SONG
 }


### PR DESCRIPTION
## Summary

- `SongEntity` was stored in Compose `mutableStateOf()` / `rememberSaveable` state; when Android saves activity instance state it tries to parcel the entire Bundle including Compose state, failing with `IllegalArgumentException`/`RuntimeException` because `SongEntity` had no `Parcelable` implementation
- Added `@Parcelize` annotation + `Parcelable` interface to `SongEntity`
- Added two private `Parceler` objects for `LocalDateTime` fields (nullable and non-nullable), using ISO-8601 string round-trip via `@WriteWith`

## Sentry issues fixed
- **ANDROID-B8**: `IllegalArgumentException: Parcel: unknown type for value SongEntity(...)` — 18,219 users, 90,100 events
- **ANDROID-BD**: `RuntimeException: Parcel: unable to marshal value SongEntity(...)` — 3,312 users, 15,322 events

## Root cause

The `kotlin-parcelize` plugin was already enabled in `domain/build.gradle.kts`. The only missing piece was the `@Parcelize` annotation on `SongEntity` and a custom parceler for `java.time.LocalDateTime`, which is not natively Parcelable.

## Test plan
- [ ] Build the `domain` module with `./gradlew :domain:assembleRelease`
- [ ] Confirm no compilation errors in `SongEntity`
- [ ] Install full-release APK and navigate to a screen that displays songs (e.g. Library); put the app in background and restore — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)