### PR TITLE
Add Wear OS metadata support (Media3 / MediaSession artwork propagation) - (album cover art + crown volume controls)

### DIFF
--- a/domain/src/commonMain/kotlin/com/maxrave/domain/data/player/GenericMediaMetadata.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/data/player/GenericMediaMetadata.kt
@@ -9,6 +9,7 @@ data class GenericMediaMetadata(
     val albumTitle: String? = null,
     val artworkUri: String? = null,
     val description: String? = null,
+    val artworkData: ByteArray? = null,
 ) {
     companion object {
         val EMPTY = GenericMediaMetadata()

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -42,6 +42,12 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
 import kotlin.math.exp
 import kotlin.math.ln
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import java.io.ByteArrayOutputStream
 
 private const val TAG = "CrossfadeExoPlayerAdapter"
 
@@ -1133,6 +1139,13 @@ internal class CrossfadeExoPlayerAdapter(
             coroutineScope.launch {
                 try {
                     transitionToState(InternalState.PREPARING)
+
+                    // Fetch and update artwork for Wear OS
+                    coroutineScope.launch {
+                        fetchArtworkData(videoId)?.let { artwork ->
+                            updateMediaItemMetadataWithArtwork(videoId, artwork)
+                        }
+                    }
 
                     // Notify media item transition
                     listeners.forEach {
@@ -2430,5 +2443,55 @@ internal class CrossfadeExoPlayerAdapter(
     private fun notifyTimelineChanged(reason: String) {
         val list = getShuffledMediaItemList()
         listeners.forEach { it.onTimelineChanged(list, reason) }
+    }
+
+    // ========== Wear OS Artwork Support ==========
+
+    private suspend fun fetchArtworkData(mediaId: String): ByteArray? {
+        val mediaItem = playlist.find { it.mediaId == mediaId } ?: return null
+        val thumbUrl = mediaItem.metadata.artworkUri?.toString() ?: return null
+
+        return try {
+            val request = ImageRequest.Builder(context)
+                .data(thumbUrl)
+                .build()
+            val result = context.imageLoader.execute(request)
+            if (result is SuccessResult) {
+                val bitmap = (result.image as? BitmapDrawable)?.bitmap ?: return null
+                val stream = ByteArrayOutputStream()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 80, stream)
+                stream.toByteArray()
+            } else null
+        } catch (e: Exception) {
+            Logger.e(TAG, "Failed to fetch artwork for $mediaId", e)
+            null
+        }
+    }
+
+    private fun updateMediaItemMetadataWithArtwork(mediaId: String, artworkData: ByteArray) {
+        val index = playlist.indexOfFirst { it.mediaId == mediaId }
+        if (index != -1) {
+            val oldItem = playlist[index]
+            val newItem = oldItem.copy(
+                metadata = oldItem.metadata.copy(
+                    artworkData = artworkData
+                )
+            )
+            playlist[index] = newItem
+            
+            // If this is the current track, tell Media3 its metadata changed
+            if (index == localCurrentMediaItemIndex) {
+                 currentPlayer?.let {
+                     val updatedMetadata = it.mediaMetadata.buildUpon()
+                         .setArtworkData(
+                             artworkData,
+                             androidx.media3.common.MediaMetadata.PICTURE_TYPE_FRONT_COVER
+                         )
+                         .build()
+                     forwardingPlayer.overrideMetadata(updatedMetadata)
+                 }
+                 forwardingPlayer.notifyMediaItemChanged()
+            }
+        }
     }
 }

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
@@ -6,6 +6,7 @@ import android.view.SurfaceView
 import android.view.TextureView
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import com.maxrave.logger.Logger
@@ -226,6 +227,10 @@ internal class DelegatingForwardingPlayer(
         if (nav.hasPreviousMediaItem()) {
             builder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
         }
+        
+        // Explicitly enable volume commands for Wear OS synchronisation
+        builder.add(Player.COMMAND_SET_VOLUME)
+        builder.add(Player.COMMAND_ADJUST_DEVICE_VOLUME)
 
         return builder.build()
     }
@@ -240,6 +245,8 @@ internal class DelegatingForwardingPlayer(
                     return true // Always allow seeking to start of current track
                 Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM ->
                     return nav.hasPreviousMediaItem()
+                Player.COMMAND_SET_VOLUME, Player.COMMAND_ADJUST_DEVICE_VOLUME ->
+                    return true
             }
         }
         return super.isCommandAvailable(command)
@@ -324,6 +331,9 @@ internal class DelegatingForwardingPlayer(
             }
         }
 
+        // Clear metadata override on delegate swap since it's a new track
+        metadataOverride = null
+
         // 4. Swap the private final `player` field
         field.set(this, newDelegate)
 
@@ -361,10 +371,23 @@ internal class DelegatingForwardingPlayer(
      * (with MediaItem + prepare()) before the ForwardingPlayer is swapped to it.
      * MediaSession uses these events to update the system notification metadata.
      */
+
+    /**
+     * Override the metadata for the current media item.
+     * watchOS FEATURE (ARTWORK + CROWN VOLUME CONTROL)
+     */
+    fun overrideMetadata(metadata: MediaMetadata?) {
+        this.metadataOverride = metadata
+    }
+    override fun getMediaMetadata(): MediaMetadata {
+        return metadataOverride ?: super.getMediaMetadata()
+    }
+    private var metadataOverride: MediaMetadata? = null
+
     fun notifyMediaItemChanged() {
         val player = wrappedPlayer
         val mediaItem = player.currentMediaItem ?: MediaItem.EMPTY
-        val metadata = player.mediaMetadata
+        val metadata = metadataOverride ?: player.mediaMetadata
         val commands = getAvailableCommands()
 
         Logger.d(TAG, "Manually notifying ${trackedListeners.size} listeners about media item change: ${metadata.title}")

--- a/media/media3/src/main/java/com/maxrave/media3/service/callback/SimpleMediaSessionCallback.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/callback/SimpleMediaSessionCallback.kt
@@ -85,10 +85,7 @@ internal class SimpleMediaSessionCallback(
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.RADIO, Bundle()))
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.SHUFFLE, Bundle()))
                 .build()
-        return MediaSession.ConnectionResult
-            .AcceptedResultBuilder(session)
-            .setAvailableSessionCommands(sessionCommands)
-            .build()
+        return MediaSession.ConnectionResult.accept(sessionCommands, MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS)
     }
 
     @UnstableApi


### PR DESCRIPTION
> Note: When using this feature in release builds, consumers may need
> to ensure MediaMetadata and artwork-related fields are not stripped
> by R8/ProGuard.

> *Great work and I love the app after only a few days of use*

# 📄 Description

## 🚀 Overview

This PR adds proper **Wear OS metadata support** by ensuring artwork and metadata updates are correctly propagated through `Media3` and `MediaSession`.

Currently, artwork updates were not reaching external controllers (e.g., Wear OS).
---

## 🧩 Changes

### 1. MediaMetadata enhancement

* Added `artworkData: ByteArray?` to `GenericMediaMetadata`

---

### 2. CrossfadeExoPlayerAdapter

* Fetches artwork asynchronously (Coil)
* Converts to `ByteArray`
* Injects artwork into current media metadata

---

### 3. DelegatingForwardingPlayer

* Introduced `metadataOverride` mechanism
* Overrides `getMediaMetadata()` to expose updated metadata
* Added manual dispatch via `notifyMediaItemChanged()`:

  * `onMediaItemTransition`
  * `onMediaMetadataChanged`
  * `onAvailableCommandsChanged`

Ensures MediaSession and external controllers receive updates immediately

---

### 4. MediaSession callback fix

* Updated `onConnect()` to explicitly accept:

  * `DEFAULT_SESSION_AND_LIBRARY_COMMANDS`
  * `DEFAULT_PLAYER_COMMANDS`

Improves compatibility with external controllers (Wear OS)

---

## 🧪 Behavior

### ✅ Debug build

* Artwork correctly updates on Wear OS + crown volume controls
* Metadata changes propagate instantly

### ❌ Before this PR

* Artwork missing on Wear OS + crown volume controls don't working

---

## 🎯 Result

* Wear OS now receives:

  * correct artwork
  * updated metadata
  * proper playback state

---

## ⚠️ Notes

* Uses a manual metadata override due to Media3 limitations when mutating active `MediaItem`
* Listener dispatch is required to notify `MediaSession` of runtime metadata changes

## Screenshots:
- SimpMusic-foss-arm64-v8a-release.apk - release 1.1.0
- Pixel Watch 4 45mm - Wear OS 6 - API 36.1
<img width="530" height="530" alt="Screenshot - SimpMusic 1 1 0 version" src="https://github.com/user-attachments/assets/891a370c-8efa-4652-8ea0-b2ed3cff2d96" />
<img width="530" height="530" alt="Screenshot_20260319_121145" src="https://github.com/user-attachments/assets/3a19ea2a-c6b5-4ecd-9094-bbfcf8345350" />

- Debug app
- Pixel Watch 4 45mm - Wear OS 6 - API 36.1
<img width="530" height="530" alt="Screenshot_20260318_122023" src="https://github.com/user-attachments/assets/b8607c73-d91b-47a1-a32a-45935dc24dbe" />
<img width="530" height="530" alt="Screenshot_20260318_122039" src="https://github.com/user-attachments/assets/01130763-4107-480f-8af7-816090a9bf8e" />


