### PR TITLE
Disable VLC video output for audio playback

### DIFF
--- a/media/media-jvm/src/main/java/com/simpmusic/media_jvm/VlcPlayerAdapter.kt
+++ b/media/media-jvm/src/main/java/com/simpmusic/media_jvm/VlcPlayerAdapter.kt
@@ -1126,6 +1126,8 @@ class VlcPlayerAdapter(
             // Extra buffering for video streams to prevent stalls near end
             options.add(":network-caching=15000")
             options.add(":http-reconnect")
+        } else {
+            options.add(":no-video")
         }
         return options.toTypedArray()
     }


### PR DESCRIPTION
This PR prevents VLC from opening an external Direct3D11 video output window during audio playback on Desktop/Windows.

The change adds the libVLC `:no-video` option only for non-video sources in `VlcPlayerAdapter.buildVlcOptions`.

Tested locally on Windows:
- Desktop app starts successfully
- Audio playback works
- The external "VLC (Direct3D11 output)" window no longer appears

Video sources are unaffected because `:no-video` is only applied when `source.isVideo == false`.

Note: this replaces the previous PR that was accidentally opened against `main` instead of `multiplatform`.