### PR TITLE
fix(player): keep foreground service alive across track swaps

### DIFF
--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -1245,31 +1245,12 @@ internal class CrossfadeExoPlayerAdapter(
                     // 4. Setup our listener on new player
                     setupPlayerListenerInternal(player)
 
-                    // 5. Swap ForwardingPlayer delegate (moves MediaSession's listeners from old to new)
-                    forwardingPlayer.swapDelegate(player)
-
-                    // 5b. Notify MediaSession about the new media item
-                    // The MediaItem was set before the swap (either during precache or above),
-                    // so MediaSession's listener missed the onMediaItemTransition event.
-                    // play() below will trigger onIsPlayingChanged which causes MediaSession
-                    // to re-query metadata, but this explicit notify is safer and ensures
-                    // the notification updates immediately even if play() is delayed.
-                    forwardingPlayer.notifyMediaItemChanged()
-
-                    // 6. NOW release old player (it has no listeners anymore)
-                    if (oldPlayer != null && oldPlayer !== player) {
-                        try {
-                            oldPlayer.stop()
-                            oldPlayer.release()
-                        } catch (e: Exception) {
-                            Logger.w(TAG, "Error releasing old player: ${e.message}")
-                        }
-                    }
-
-                    // Audio focus is held at the adapter level (see Audio Focus section),
-                    // not per-player, so it survives this swap (#2155).
-
-                    // Apply settings
+                    // 4b. Apply settings and set the play state BEFORE swapping the
+                    // MediaSession delegate. The session must never observe this player
+                    // with playWhenReady=false while a track should be playing: media3
+                    // treats that as the user disengaging, arms its user-engaged
+                    // foreground-service timeout and demotes the service 10 minutes
+                    // later in the middle of playback (#2233).
                     player.volume = internalVolume
                     player.playbackParameters = PlaybackParameters(internalPlaybackSpeed, internalPlaybackPitch)
                     player.skipSilenceEnabled = internalSkipSilence
@@ -1289,6 +1270,28 @@ internal class CrossfadeExoPlayerAdapter(
                         player.pause()
                         transitionToState(InternalState.READY)
                     }
+
+                    // 5. Swap ForwardingPlayer delegate (moves MediaSession's listeners from old to new)
+                    forwardingPlayer.swapDelegate(player)
+
+                    // 5b. Notify MediaSession about the new media item and play state.
+                    // The MediaItem was set and play() was called before the swap, so
+                    // MediaSession's listener missed those events; this explicit notify
+                    // makes it re-read the player (metadata and playWhenReady=true).
+                    forwardingPlayer.notifyMediaItemChanged()
+
+                    // 6. NOW release old player (it has no listeners anymore)
+                    if (oldPlayer != null && oldPlayer !== player) {
+                        try {
+                            oldPlayer.stop()
+                            oldPlayer.release()
+                        } catch (e: Exception) {
+                            Logger.w(TAG, "Error releasing old player: ${e.message}")
+                        }
+                    }
+
+                    // Audio focus is held at the adapter level (see Audio Focus section),
+                    // not per-player, so it survives this swap (#2155).
 
                     forwardingPlayer.suppressPlaybackEnded = false
 

--- a/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
@@ -200,7 +200,14 @@ internal class SimpleMediaService :
         session: MediaSession,
         startInForegroundRequired: Boolean,
     ) {
-        super.onUpdateNotification(session, startInForegroundRequired)
+        // Media3's user-engaged tracking can go stale across delegate swaps and
+        // demote the service while music is still playing (#2233). Trust the
+        // actual player state: while it plays, keep the service in the foreground.
+        val player = session.player
+        val isActuallyPlaying =
+            player.playWhenReady &&
+                (player.playbackState == Player.STATE_READY || player.playbackState == Player.STATE_BUFFERING)
+        super.onUpdateNotification(session, startInForegroundRequired || isActuallyPlaying)
     }
 
     @UnstableApi


### PR DESCRIPTION
This fixes music randomly stopping between tracks after a few songs on Android (maxrave-dev/SimpMusic#2233), the cause that remained after the audio-focus fix from maxrave-dev/SimpMusic#2022.

During a track swap, `loadAndPlayTrackInternal` let MediaSession observe the promoted precached player with `playWhenReady=false` before `play()` ran. Media3 samples that as user disengagement and arms its 10-minute foreground-service timeout, which never gets cancelled: the service is demoted mid-playback, Android stops it as idle, cuts the app's network, and playback starves at the next track (evidence in the issue).

- `loadAndPlayTrackInternal`: start the new player before `swapDelegate()` / `notifyMediaItemChanged()` (the crossfade path already does this).
- `SimpleMediaService.onUpdateNotification`: keep the service in the foreground while the player is actually playing, self-healing any wrong demotion.

Tested on a Galaxy S23 (Android 16): 1h+ of background playback across 14 track changes with `isForeground=true` throughout, where 1.5.1 stopped within ~15 minutes.

Fixes maxrave-dev/SimpMusic#2233
