### PR TITLE
Fix 'Play Next' duplicating queue

### DIFF
--- a/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
+++ b/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
@@ -2089,8 +2089,12 @@ class JvmMediaPlayerHandlerImpl(
             _queueData.update {
                 it
                     .copy(
+                        data =
+                            it.data.copy(
+                                listTracks = catalogMetadata,
+                            ),
                         queueState = QueueData.StateSource.STATE_INITIALIZED,
-                    ).addTrackList(catalogMetadata)
+                    )
             }
             reorderShuffledQueue(player.getCurrentMediaTimeLine())
         }


### PR DESCRIPTION
Hi, I found a very annoying bug after choosing the 'Play Next' button on the JVM/Desktop version. 

When you click 'Play Next', the entire existing queue gets duplicated and appended after itself (with the new track inserted into the duplicate), rather than the new track simply being inserted once at the correct position., creating a visually unclear queue. 

The functionality of the play next button is completely fine, it simply confuses the user on what the queue actually is. You can see the video below that demonstrates the bug. 

**Before the fix**

https://github.com/user-attachments/assets/c8bd2a7f-ff23-4159-b196-8cdef000a8dc

**After the fix**


https://github.com/user-attachments/assets/7c2b78ec-ec8f-4fa9-ba10-eaf8d7e03505

The fix was relatively simple, inside `playNext()` in `JvmMediaPlayerHandlerImpl,` the correct queue is built but it then calls `.addTrackList(catalogMetadata)`, which appends the queue state instead of replacing it. This was fixed by replicating the logic found inside` playNext()` in `MediaServiceHandlerImpl.kt`: `.copy(
                    data =
                        it.data.copy(
                            listTracks = catalogMetadata,
                        ),
                    queueState = QueueData.StateSource.STATE_INITIALIZED,
                )`  that replaces the entire queue, instead of appending. 