### PR TITLE
fix(android-auto): silent start, MODE resume, and search play

### DIFF
--- a/common/src/commonMain/kotlin/com/maxrave/common/Config.kt
+++ b/common/src/commonMain/kotlin/com/maxrave/common/Config.kt
@@ -498,6 +498,8 @@ object MEDIA_CUSTOM_COMMAND {
     const val REPEAT = "repeat"
     const val RADIO = "radio"
     const val SHUFFLE = "shuffle"
+    /** Custom previous for Android Auto when Like occupies SLOT_BACK. */
+    const val PREVIOUS = "previous"
 
     // Android Auto (Car App Library): asks the session for its platform token
     const val GET_PLATFORM_TOKEN = "get_platform_token"

--- a/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
@@ -902,7 +902,7 @@ internal class DataStoreManagerImpl(
 
     override val androidAutoLikeInsteadOfPrevious: Flow<String> =
         settingsDataStore.data.map { preferences ->
-            preferences[ANDROID_AUTO_LIKE_INSTEAD_OF_PREVIOUS] ?: TRUE
+            preferences[ANDROID_AUTO_LIKE_INSTEAD_OF_PREVIOUS] ?: FALSE
         }
 
     override suspend fun setAndroidAutoLikeInsteadOfPrevious(enabled: Boolean) {

--- a/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
@@ -900,6 +900,19 @@ internal class DataStoreManagerImpl(
         }
     }
 
+    override val androidAutoLikeInsteadOfPrevious: Flow<String> =
+        settingsDataStore.data.map { preferences ->
+            preferences[ANDROID_AUTO_LIKE_INSTEAD_OF_PREVIOUS] ?: TRUE
+        }
+
+    override suspend fun setAndroidAutoLikeInsteadOfPrevious(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            settingsDataStore.edit { settings ->
+                settings[ANDROID_AUTO_LIKE_INSTEAD_OF_PREVIOUS] = if (enabled) TRUE else FALSE
+            }
+        }
+    }
+
     override val shouldShowLogInRequiredAlert =
         settingsDataStore.data.map { preferences ->
             preferences[SHOULD_SHOW_LOG_IN_REQUIRED_ALERT] ?: TRUE
@@ -1508,6 +1521,8 @@ internal class DataStoreManagerImpl(
         val ENDLESS_QUEUE = stringPreferencesKey("endless_queue")
         val KEEP_YOUTUBE_PLAYLIST_OFFLINE = stringPreferencesKey("keep_youtube_playlist_offline")
         val COMBINE_LOCAL_AND_YOUTUBE_LIKED = stringPreferencesKey("combine_local_and_youtube_liked")
+        val ANDROID_AUTO_LIKE_INSTEAD_OF_PREVIOUS =
+            stringPreferencesKey("android_auto_like_instead_of_previous")
         val SHOULD_SHOW_LOG_IN_REQUIRED_ALERT = stringPreferencesKey("should_show_log_in_required_alert")
         val AUTO_CHECK_FOR_UPDATES = stringPreferencesKey("auto_check_for_updates")
         val UPDATE_CHANNEL = stringPreferencesKey("update_channel")

--- a/data/src/commonMain/kotlin/com/maxrave/data/di/RepositoryModule.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/di/RepositoryModule.kt
@@ -78,7 +78,7 @@ val repositoryModule =
         }
 
         single<SongRepository>(createdAtStart = true) {
-            SongRepositoryImpl(get(), get(), get())
+            SongRepositoryImpl(get(), get(), get(), get())
         }
 
         single<StreamRepository>(createdAtStart = true) {

--- a/data/src/commonMain/kotlin/com/maxrave/data/repository/SongRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/repository/SongRepositoryImpl.kt
@@ -14,8 +14,10 @@ import com.maxrave.domain.data.model.download.DownloadProgress
 import com.maxrave.domain.data.model.streams.YouTubeWatchEndpoint
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.manager.DataStoreManager.Values.TRUE
+import com.maxrave.domain.repository.PlaylistRepository
 import com.maxrave.domain.repository.SongRepository
 import com.maxrave.domain.utils.Resource
+import com.maxrave.domain.utils.toSongEntity
 import com.maxrave.kotlinytmusicscraper.YouTube
 import com.maxrave.kotlinytmusicscraper.models.SongItem
 import com.maxrave.kotlinytmusicscraper.models.WatchEndpoint
@@ -36,12 +38,16 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.LocalDateTime
 
 private const val TAG = "SongRepositoryImpl"
+private const val YT_LIKED_SYNC_TTL_MS = 5 * 60 * 1000L
 
 internal class SongRepositoryImpl(
     private val dataStoreManager: DataStoreManager,
     private val localDataSource: LocalDataSource,
     private val youTube: YouTube,
+    private val playlistRepository: PlaylistRepository,
 ) : SongRepository {
+    @Volatile
+    private var lastYtLikedSyncMs: Long = 0L
     override fun getAllSongs(limit: Int): Flow<List<SongEntity>> =
         flow {
             emit(localDataSource.getAllSongs(limit))
@@ -135,17 +141,19 @@ internal class SongRepositoryImpl(
         likeStatus: Int,
     ) = withContext(Dispatchers.Main) {
         localDataSource.updateLiked(likeStatus, videoId)
-//        if (dataStoreManager.combineLocalAndYouTubeLiked.first() == TRUE) {
-//            if (likeStatus == 1) {
-//                addToYouTubeLiked(videoId).collect { result ->
-//                    Logger.d(TAG, "updateLikeStatus -> addToYouTubeLiked: $result")
-//                }
-//            } else {
-//                removeFromYouTubeLiked(videoId).collect { result ->
-//                    Logger.d(TAG, "updateLikeStatus -> removeFromYouTubeLiked: $result")
-//                }
-//            }
-//        }
+        if (dataStoreManager.combineLocalAndYouTubeLiked.first() == TRUE &&
+            dataStoreManager.loggedIn.first() == TRUE
+        ) {
+            if (likeStatus == 1) {
+                addToYouTubeLiked(videoId).collect { result ->
+                    Logger.d(TAG, "updateLikeStatus -> addToYouTubeLiked: $result")
+                }
+            } else {
+                removeFromYouTubeLiked(videoId).collect { result ->
+                    Logger.d(TAG, "updateLikeStatus -> removeFromYouTubeLiked: $result")
+                }
+            }
+        }
     }
 
     override fun updateSongInLibrary(
@@ -350,6 +358,46 @@ internal class SongRepositoryImpl(
                 }
             }
         }.flowOn(Dispatchers.IO)
+
+    override suspend fun syncYouTubeLikedToLocal(force: Boolean): Int =
+        withContext(Dispatchers.IO) {
+            if (dataStoreManager.combineLocalAndYouTubeLiked.first() != TRUE) {
+                return@withContext 0
+            }
+            if (dataStoreManager.loggedIn.first() != TRUE) {
+                return@withContext 0
+            }
+            val now = System.currentTimeMillis()
+            if (!force && now - lastYtLikedSyncMs < YT_LIKED_SYNC_TTL_MS) {
+                Logger.d(TAG, "syncYouTubeLikedToLocal: skipped (TTL)")
+                return@withContext 0
+            }
+            runCatching {
+                val resource =
+                    playlistRepository
+                        .getFullPlaylistData("LM", "")
+                        .lastOrNull()
+                val tracks =
+                    (resource as? Resource.Success)?.data?.tracks.orEmpty()
+                if (tracks.isEmpty()) {
+                    Logger.w(TAG, "syncYouTubeLikedToLocal: empty LM or error=$resource")
+                    return@runCatching 0
+                }
+                var applied = 0
+                for (track in tracks) {
+                    val entity = track.toSongEntity().copy(liked = true)
+                    localDataSource.insertSong(entity)
+                    localDataSource.updateLiked(1, track.videoId)
+                    applied++
+                }
+                lastYtLikedSyncMs = now
+                Logger.d(TAG, "syncYouTubeLikedToLocal: applied=$applied")
+                applied
+            }.getOrElse {
+                Logger.e(TAG, "syncYouTubeLikedToLocal failed: ${it.message}")
+                0
+            }
+        }
 
     override fun downloadToFile(
         track: Track,

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/data/player/GenericCommandButton.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/data/player/GenericCommandButton.kt
@@ -16,4 +16,7 @@ sealed class GenericCommandButton {
     ) : GenericCommandButton()
 
     data object Radio : GenericCommandButton()
+
+    /** On-screen previous when Like has taken the compact back slot on Android Auto. */
+    data object Previous : GenericCommandButton()
 }

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
@@ -214,7 +214,7 @@ interface DataStoreManager {
 
     suspend fun setCombineLocalAndYouTubeLiked(combine: Boolean)
 
-    /** Replace AA previous transport with Like; wheel previous likes. Default on. */
+    /** Replace previous transport with Like (media notification + Android Auto). Default off. */
     val androidAutoLikeInsteadOfPrevious: Flow<String>
 
     suspend fun setAndroidAutoLikeInsteadOfPrevious(enabled: Boolean)

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
@@ -214,6 +214,11 @@ interface DataStoreManager {
 
     suspend fun setCombineLocalAndYouTubeLiked(combine: Boolean)
 
+    /** Replace AA previous transport with Like; wheel previous likes. Default on. */
+    val androidAutoLikeInsteadOfPrevious: Flow<String>
+
+    suspend fun setAndroidAutoLikeInsteadOfPrevious(enabled: Boolean)
+
     val shouldShowLogInRequiredAlert: Flow<String>
 
     suspend fun setShouldShowLogInRequiredAlert(shouldShow: Boolean)

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/repository/SongRepository.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/repository/SongRepository.kt
@@ -98,6 +98,14 @@ interface SongRepository {
 
     suspend fun removeFromYouTubeLiked(mediaId: String?): Flow<Int>
 
+    /**
+     * When "Replace Favorite by YouTube Liked" is enabled and the user is logged in,
+     * fetch YouTube Liked Music (LM) and mark those tracks as liked in Room.
+     * @param force ignore the short TTL cache used to avoid refetching on every AA browse
+     * @return number of tracks applied, or 0 if skipped/failed
+     */
+    suspend fun syncYouTubeLikedToLocal(force: Boolean = false): Int
+
     fun downloadToFile(
         track: Track,
         path: String,

--- a/media/media3/src/main/java/com/maxrave/media3/di/Media3ServiceModule.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/di/Media3ServiceModule.kt
@@ -212,6 +212,7 @@ private val mediaServiceModule =
                 androidApplication(),
                 get<CoroutineScope>(named(SERVICE_SCOPE)),
                 get<MediaPlayerHandler>(),
+                get<DataStoreManager>(),
                 get<SearchRepository>(),
                 get<SongRepository>(),
                 get<LocalPlaylistRepository>(),

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -4,6 +4,11 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.media.AudioPlaybackConfiguration
+import android.os.Handler
+import android.os.Looper
+import androidx.car.app.connection.CarConnection
+import androidx.lifecycle.Observer
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -180,9 +185,56 @@ internal class CrossfadeExoPlayerAdapter(
     @Volatile
     private var hasAudioFocus = false
 
-    /** True when focus was lost transiently so playback should auto-resume on regain. */
+    /** True when focus/route was lost while playing so we should resume on AA reconnect. */
     @Volatile
     private var resumeOnFocusGain = false
+
+    /**
+     * True while [pause] was requested by the app/user (not AudioBecomingNoisy / focus).
+     * Used so an ExoPlayer-driven pause from route loss can still arm auto-resume.
+     */
+    @Volatile
+    private var intentionalPause = false
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var carConnection: CarConnection? = null
+
+    private var carResumeJob: Job? = null
+
+    /**
+     * When AA projection returns after MODE (USB/radio), resume only if we were interrupted
+     * while playing — not if the user paused or another music app took over.
+     */
+    private val carConnectionObserver =
+        Observer<Int> { connectionType ->
+            Logger.d(TAG, "CarConnection type=$connectionType resumePending=$resumeOnFocusGain")
+            if (connectionType != CarConnection.CONNECTION_TYPE_PROJECTION) return@Observer
+            carResumeJob?.cancel()
+            carResumeJob =
+                coroutineScope.launch {
+                    // Let the wireless AA audio route settle after MODE.
+                    delay(600)
+                    resumeIfInterrupted()
+                }
+        }
+
+    /**
+     * If YouTube Music / Spotify starts playing after we lost focus, drop auto-resume so we
+     * don't steal their session when AA reconnects.
+     */
+    private val audioPlaybackCallback =
+        object : AudioManager.AudioPlaybackCallback() {
+            override fun onPlaybackConfigChanged(configs: List<AudioPlaybackConfiguration>) {
+                if (!resumeOnFocusGain) return
+                // Public AudioPlaybackConfiguration has no client uid; if music is active while
+                // we are not playing, another app took the stream.
+                if (internalState != InternalState.PLAYING && audioManager?.isMusicActive == true) {
+                    resumeOnFocusGain = false
+                    Logger.d(TAG, "Cleared resumeOnFocusGain: another app is playing media")
+                }
+            }
+        }
 
     private val audioFocusListener =
         AudioManager.OnAudioFocusChangeListener { focusChange ->
@@ -197,16 +249,30 @@ internal class CrossfadeExoPlayerAdapter(
                 }
 
                 AudioManager.AUDIOFOCUS_LOSS -> {
-                    // Permanent loss (another app took over): pause and stop tracking focus.
-                    resumeOnFocusGain = false
+                    // Car MODE → USB/radio reports permanent loss. Remember to resume when
+                    // AA reconnects unless the user already paused intentionally.
                     hasAudioFocus = false
-                    pause()
+                    when {
+                        internalState == InternalState.PLAYING -> {
+                            resumeOnFocusGain = true
+                            pauseInternal(intentional = false)
+                            Logger.d(TAG, "AUDIOFOCUS_LOSS while playing → resume armed")
+                        }
+                        resumeOnFocusGain && !intentionalPause -> {
+                            // AudioBecomingNoisy already paused and armed resume — keep it.
+                            Logger.d(TAG, "AUDIOFOCUS_LOSS keeping resumeOnFocusGain")
+                        }
+                        else -> {
+                            resumeOnFocusGain = false
+                            Logger.d(TAG, "AUDIOFOCUS_LOSS (no auto-resume)")
+                        }
+                    }
                 }
 
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
                     // Temporary loss (e.g. an incoming call): pause and remember to resume.
-                    resumeOnFocusGain = internalState == InternalState.PLAYING
-                    pause()
+                    resumeOnFocusGain = internalState == InternalState.PLAYING || resumeOnFocusGain
+                    pauseInternal(intentional = false)
                 }
 
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
@@ -216,6 +282,16 @@ internal class CrossfadeExoPlayerAdapter(
                 }
             }
         }
+
+    init {
+        runCatching {
+            carConnection = CarConnection(context.applicationContext)
+            carConnection?.type?.observeForever(carConnectionObserver)
+        }.onFailure {
+            Logger.e(TAG, "CarConnection setup failed: ${it.message}")
+        }
+        audioManager?.registerAudioPlaybackCallback(audioPlaybackCallback, mainHandler)
+    }
 
     private val audioFocusRequest: AudioFocusRequest by lazy {
         AudioFocusRequest
@@ -231,10 +307,13 @@ internal class CrossfadeExoPlayerAdapter(
             .build()
     }
 
-    /** Request app-level audio focus once; idempotent while focus is held. */
+    /**
+     * Request app-level audio focus. Always re-issues the system request (even if we
+     * already believe we hold focus) so Android Auto / Bluetooth route switches re-attach
+     * the media stream to the car — skipping the call left playback "playing" with silence.
+     */
     private fun requestAudioFocusInternal(): Boolean {
         val am = audioManager ?: return true
-        if (hasAudioFocus) return true
         val granted = am.requestAudioFocus(audioFocusRequest) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
         hasAudioFocus = granted
         Logger.d(TAG, "requestAudioFocus -> granted=$granted")
@@ -358,6 +437,21 @@ internal class CrossfadeExoPlayerAdapter(
                 override fun seekToPrevious(): Unit = this@CrossfadeExoPlayerAdapter.seekToPrevious()
 
                 override fun seekToPreviousMediaItem(): Unit = this@CrossfadeExoPlayerAdapter.seekToPreviousMediaItem()
+            }
+
+        // MediaSession / Android Auto call Player.play() on forwardingPlayer. Route those
+        // through the adapter so audio focus is requested (ExoPlayers use handleAudioFocus=false).
+        forwardingPlayer.playbackControlProvider =
+            object : DelegatingForwardingPlayer.PlaybackControlProvider {
+                override fun play(): Unit = this@CrossfadeExoPlayerAdapter.play()
+
+                override fun pause(): Unit = this@CrossfadeExoPlayerAdapter.pause()
+
+                override var playWhenReady: Boolean
+                    get() = this@CrossfadeExoPlayerAdapter.playWhenReady
+                    set(value) {
+                        this@CrossfadeExoPlayerAdapter.playWhenReady = value
+                    }
             }
     }
 
@@ -511,6 +605,8 @@ internal class CrossfadeExoPlayerAdapter(
 
     override fun play() {
         Logger.d(TAG, "play() called (state: $internalState, playWhenReady: $internalPlayWhenReady)")
+        resumeOnFocusGain = false
+        intentionalPause = false
         castRemotePlayer?.let { remote ->
             internalPlayWhenReady = true
             remote.play()
@@ -520,7 +616,11 @@ internal class CrossfadeExoPlayerAdapter(
             when (internalState) {
                 InternalState.READY, InternalState.ENDED, InternalState.PAUSED -> {
                     currentPlayer?.let { player ->
-                        requestAudioFocusInternal()
+                        if (!requestAudioFocusInternal()) {
+                            Logger.w(TAG, "Play aborted: audio focus not granted")
+                            internalPlayWhenReady = false
+                            return@launch
+                        }
                         player.play()
                         transitionToState(InternalState.PLAYING)
                         internalPlayWhenReady = true
@@ -545,7 +645,40 @@ internal class CrossfadeExoPlayerAdapter(
     }
 
     override fun pause() {
-        Logger.d(TAG, "pause() called (state: $internalState, playWhenReady: $internalPlayWhenReady)")
+        pauseInternal(intentional = true)
+    }
+
+    /**
+     * Resume after a car audio-source switch (MODE → USB/radio → AA) if playback was
+     * interrupted rather than paused by the user / taken over by another music app.
+     */
+    fun resumeIfInterrupted() {
+        if (!resumeOnFocusGain) {
+            Logger.d(TAG, "resumeIfInterrupted: nothing pending")
+            return
+        }
+        if (otherAppPlayingMedia()) {
+            resumeOnFocusGain = false
+            Logger.d(TAG, "resumeIfInterrupted: skipped — other app playing")
+            return
+        }
+        Logger.w(TAG, "resumeIfInterrupted: resuming after car/source interruption")
+        resumeOnFocusGain = false
+        play()
+    }
+
+    private fun otherAppPlayingMedia(): Boolean {
+        // We're paused for resume; active music means another app owns playback.
+        if (internalState == InternalState.PLAYING) return false
+        return audioManager?.isMusicActive == true
+    }
+
+    private fun pauseInternal(intentional: Boolean) {
+        Logger.d(TAG, "pause() called intentional=$intentional (state: $internalState, playWhenReady: $internalPlayWhenReady)")
+        if (intentional) {
+            resumeOnFocusGain = false
+            intentionalPause = true
+        }
         castRemotePlayer?.let { remote ->
             internalPlayWhenReady = false
             remote.pause()
@@ -1174,6 +1307,15 @@ internal class CrossfadeExoPlayerAdapter(
         currentLoadJob?.cancel()
         precacheJob?.cancel()
         positionUpdateJob?.cancel()
+        carResumeJob?.cancel()
+
+        runCatching {
+            carConnection?.type?.removeObserver(carConnectionObserver)
+        }
+        carConnection = null
+        runCatching {
+            audioManager?.unregisterAudioPlaybackCallback(audioPlaybackCallback)
+        }
 
         // Cancel crossfade
         crossfadeJob?.cancel()
@@ -1399,9 +1541,15 @@ internal class CrossfadeExoPlayerAdapter(
 
                     // Auto-play if requested
                     if (shouldPlay) {
-                        requestAudioFocusInternal()
-                        player.play()
-                        transitionToState(InternalState.PLAYING)
+                        if (!requestAudioFocusInternal()) {
+                            Logger.w(TAG, "Auto-play aborted: audio focus not granted")
+                            player.pause()
+                            transitionToState(InternalState.READY)
+                            internalPlayWhenReady = false
+                        } else {
+                            player.play()
+                            transitionToState(InternalState.PLAYING)
+                        }
                     } else {
                         player.pause()
                         transitionToState(InternalState.READY)
@@ -1494,6 +1642,13 @@ internal class CrossfadeExoPlayerAdapter(
                     } else {
                         if (internalState == InternalState.PLAYING) {
                             if (!player.playWhenReady) {
+                                // ExoPlayer paused itself (AudioBecomingNoisy on MODE/USB switch,
+                                // etc.) — arm auto-resume unless we paused on purpose.
+                                if (!intentionalPause) {
+                                    resumeOnFocusGain = true
+                                    Logger.d(TAG, "External pause → resumeOnFocusGain=true")
+                                }
+                                intentionalPause = false
                                 transitionToState(InternalState.PAUSED)
                                 notifyEqualizerIntent(false)
                             }
@@ -1789,8 +1944,13 @@ internal class CrossfadeExoPlayerAdapter(
                 forwardingPlayer.swapDelegate(nextPlayer)
 
                 // 2. Now play - MediaSession's listener is attached and receives state change events
-                requestAudioFocusInternal()
-                nextPlayer.play()
+                if (!requestAudioFocusInternal()) {
+                    Logger.w(TAG, "Crossfade play aborted: audio focus not granted")
+                    nextPlayer.pause()
+                    // Still commit the incoming track as current so UI/queue stay consistent.
+                } else {
+                    nextPlayer.play()
+                }
 
                 forwardingPlayer.suppressPlaybackEnded = false
 

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
@@ -78,6 +78,46 @@ internal class DelegatingForwardingPlayer(
      */
     var playlistNavigationProvider: PlaylistNavigationProvider? = null
 
+    /**
+     * Routes MediaSession / Android Auto transport controls through the adapter so
+     * app-level audio focus is requested. Each ExoPlayer is built with
+     * `handleAudioFocus=false`; without this bridge, [play] would hit ExoPlayer
+     * directly and resume visually with no car audio (silent AA startup).
+     */
+    interface PlaybackControlProvider {
+        fun play()
+
+        fun pause()
+
+        var playWhenReady: Boolean
+    }
+
+    /**
+     * Set by [CrossfadeExoPlayerAdapter]. When null, play/pause fall back to the
+     * underlying ExoPlayer (no adapter-level audio focus).
+     */
+    var playbackControlProvider: PlaybackControlProvider? = null
+
+    override fun play() {
+        playbackControlProvider?.play() ?: super.play()
+    }
+
+    override fun pause() {
+        playbackControlProvider?.pause() ?: super.pause()
+    }
+
+    override fun setPlayWhenReady(playWhenReady: Boolean) {
+        val provider = playbackControlProvider
+        if (provider != null) {
+            provider.playWhenReady = playWhenReady
+        } else {
+            super.setPlayWhenReady(playWhenReady)
+        }
+    }
+
+    override fun getPlayWhenReady(): Boolean =
+        playbackControlProvider?.playWhenReady ?: super.getPlayWhenReady()
+
     // ========== Playback-Ended Suppression ==========
 
     /**

--- a/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
@@ -155,8 +155,8 @@ fun GenericCommandButton.toCommandButton(
             builder.build()
         }
         GenericCommandButton.Previous -> {
-            // Stock previous glyph, but force OVERFLOW: ICON_PREVIOUS defaults to SLOT_BACK
-            // and would otherwise steal the compact previous slot from Like.
+            // No setCustomIconResId: let the host draw ICON_PREVIOUS with the same OEM
+            // asset family as system Next. Force OVERFLOW so we don't steal SLOT_BACK from Like.
             CommandButton
                 .Builder(CommandButton.ICON_PREVIOUS)
                 .setSlots(CommandButton.SLOT_OVERFLOW)

--- a/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
@@ -116,34 +116,52 @@ fun MediaItem.isSong(): Boolean = this.mediaMetadata.description?.contains(MERGI
 @UnstableApi
 fun MediaItem.isVideo(): Boolean = this.mediaMetadata.description?.contains(MERGING_DATA_TYPE.VIDEO) == true
 
-fun GenericCommandButton.toCommandButton(context: Context): CommandButton =
+@UnstableApi
+fun GenericCommandButton.toCommandButton(
+    context: Context,
+    putLikeInBackSlot: Boolean = false,
+): CommandButton =
     when (this) {
         is GenericCommandButton.Like -> {
             val liked = this.isLiked
+            val builder =
+                CommandButton
+                    .Builder(
+                        if (liked) {
+                            CommandButton.ICON_HEART_FILLED
+                        } else {
+                            CommandButton.ICON_HEART_UNFILLED
+                        },
+                        // Resource fallback for hosts (e.g. AA templated surface) that
+                        // don't map the media3 icon constants
+                    ).setCustomIconResId(
+                        if (liked) {
+                            R.drawable.baseline_favorite_24
+                        } else {
+                            R.drawable.baseline_favorite_border_24
+                        },
+                    ).setDisplayName(
+                        if (liked) {
+                            context.getString(R.string.liked)
+                        } else {
+                            context.getString(R.string.like)
+                        },
+                    ).setSessionCommand(SessionCommand(MEDIA_CUSTOM_COMMAND.LIKE, Bundle()))
+            if (putLikeInBackSlot) {
+                // Compact back/previous slot only — do not also claim overflow, and do not
+                // compete with a custom Previous that uses ICON_PREVIOUS (defaults to BACK).
+                builder.setSlots(CommandButton.SLOT_BACK)
+            }
+            builder.build()
+        }
+        GenericCommandButton.Previous -> {
+            // Stock previous glyph, but force OVERFLOW: ICON_PREVIOUS defaults to SLOT_BACK
+            // and would otherwise steal the compact previous slot from Like.
             CommandButton
-                .Builder(
-                    if (liked) {
-                        CommandButton.ICON_HEART_FILLED
-                    } else {
-                        CommandButton.ICON_HEART_UNFILLED
-                    },
-                    // Resource fallback for hosts (e.g. AA templated surface) that
-                    // don't map the media3 icon constants
-                ).setCustomIconResId(
-                    if (liked) {
-                        R.drawable.baseline_favorite_24
-                    } else {
-                        R.drawable.baseline_favorite_border_24
-                    },
-                ).setDisplayName(
-                    if (liked) {
-                        context.getString(R.string.liked)
-                    } else {
-                        context.getString(
-                            R.string.like,
-                        )
-                    },
-                ).setSessionCommand(SessionCommand(MEDIA_CUSTOM_COMMAND.LIKE, Bundle()))
+                .Builder(CommandButton.ICON_PREVIOUS)
+                .setSlots(CommandButton.SLOT_OVERFLOW)
+                .setDisplayName(context.getString(R.string.previous))
+                .setSessionCommand(SessionCommand(MEDIA_CUSTOM_COMMAND.PREVIOUS, Bundle()))
                 .build()
         }
         GenericCommandButton.Radio -> {
@@ -204,3 +222,34 @@ fun GenericCommandButton.toCommandButton(context: Context): CommandButton =
                 ).build()
         }
     }
+
+/**
+ * Default: Like first (fullscreen / overflow position).
+ * AA swap: Previous first in overflow (Like's old spot); Like alone in [CommandButton.SLOT_BACK].
+ */
+@UnstableApi
+fun List<GenericCommandButton>.toMediaButtonPreferences(
+    context: Context,
+    androidAutoLikeInsteadOfPrevious: Boolean,
+): List<CommandButton> {
+    if (!androidAutoLikeInsteadOfPrevious) {
+        return map { it.toCommandButton(context, putLikeInBackSlot = false) }
+    }
+    val like = filterIsInstance<GenericCommandButton.Like>().firstOrNull()
+    val rest =
+        filterNot { it is GenericCommandButton.Like || it is GenericCommandButton.Previous }
+    // Like listed before other BACK-capable icons so SLOT_BACK assignment is unambiguous;
+    // Previous is constrained to OVERFLOW and listed first among overflow customs.
+    val ordered =
+        buildList {
+            if (like != null) add(like)
+            add(GenericCommandButton.Previous)
+            addAll(rest)
+        }
+    return ordered.map {
+        it.toCommandButton(
+            context,
+            putLikeInBackSlot = it is GenericCommandButton.Like,
+        )
+    }
+}

--- a/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
@@ -30,7 +30,7 @@ import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.mediaservice.handler.MediaPlayerHandler
 import com.maxrave.logger.Logger
 import com.maxrave.media3.R
-import com.maxrave.media3.extension.toCommandButton
+import com.maxrave.media3.extension.toMediaButtonPreferences
 import com.maxrave.media3.utils.CoilBitmapLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -114,11 +114,20 @@ internal class SimpleMediaService :
                 )
         }
 
-        simpleMediaServiceHandler.onUpdateNotification = { list ->
-            val commandButtonList = list.map { it.toCommandButton(this) }
+        fun applyMediaButtonPreferences(list: List<com.maxrave.domain.data.player.GenericCommandButton>) {
+            val aaLikeEnabled =
+                runBlocking {
+                    dataStoreManager.androidAutoLikeInsteadOfPrevious.first() == DataStoreManager.TRUE
+                }
+            // AA now-playing is driven by the same platform/media-notification session as the
+            // phone notification, so the AA layout must be applied session-wide when enabled.
             mediaSession?.setMediaButtonPreferences(
-                commandButtonList,
+                list.toMediaButtonPreferences(this, aaLikeEnabled),
             )
+        }
+
+        simpleMediaServiceHandler.onUpdateNotification = { list ->
+            applyMediaButtonPreferences(list)
         }
 
         val sessionToken = SessionToken(this, ComponentName(this, SimpleMediaService::class.java))
@@ -173,10 +182,7 @@ internal class SimpleMediaService :
         }
 
         simpleMediaServiceHandler.onUpdateNotification = { list ->
-            val commandButtonList = list.map { it.toCommandButton(this) }
-            mediaSession?.setMediaButtonPreferences(
-                commandButtonList,
-            )
+            applyMediaButtonPreferences(list)
         }
     }
 

--- a/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
@@ -16,16 +16,22 @@ import android.os.Build
 import android.os.IBinder
 import androidx.core.content.getSystemService
 import androidx.media3.common.Player
+import androidx.media3.common.Player.COMMAND_GET_TIMELINE
+import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS
+import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaController
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
 import androidx.media3.ui.DefaultMediaDescriptionAdapter
 import androidx.media3.ui.PlayerNotificationManager
 import com.google.common.util.concurrent.MoreExecutors
+import com.maxrave.common.MEDIA_CUSTOM_COMMAND
 import com.maxrave.common.MEDIA_NOTIFICATION
+import com.maxrave.domain.data.player.GenericCommandButton
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.mediaservice.handler.MediaPlayerHandler
 import com.maxrave.logger.Logger
@@ -34,6 +40,7 @@ import com.maxrave.media3.extension.toMediaButtonPreferences
 import com.maxrave.media3.utils.CoilBitmapLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -114,20 +121,86 @@ internal class SimpleMediaService :
                 )
         }
 
-        fun applyMediaButtonPreferences(list: List<com.maxrave.domain.data.player.GenericCommandButton>) {
+        fun currentCommandButtons(): List<GenericCommandButton> {
+            val control = simpleMediaServiceHandler.controlState.value
+            return listOf(
+                GenericCommandButton.Like(control.isLiked),
+                GenericCommandButton.Shuffle(isShuffled = control.isShuffle),
+                GenericCommandButton.Repeat(repeatState = control.repeatState),
+                GenericCommandButton.Radio,
+            )
+        }
+
+        fun isCarOrPlatformController(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+        ): Boolean =
+            session.isMediaNotificationController(controller) ||
+                session.isAutoCompanionController(controller) ||
+                session.isAutomotiveController(controller) ||
+                controller.packageName == "com.google.android.projection.gearhead" ||
+                controller.packageName.contains("projection", ignoreCase = true) ||
+                controller.packageName.contains("gearhead", ignoreCase = true)
+
+        fun sessionCommandsWithCustoms() =
+            MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
+                .buildUpon()
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.LIKE, android.os.Bundle()))
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.REPEAT, android.os.Bundle()))
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.RADIO, android.os.Bundle()))
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.SHUFFLE, android.os.Bundle()))
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.PREVIOUS, android.os.Bundle()))
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.GET_PLATFORM_TOKEN, android.os.Bundle()))
+                .build()
+
+        fun applyTransportLayout(list: List<GenericCommandButton> = currentCommandButtons()) {
+            val session = mediaSession ?: return
             val aaLikeEnabled =
                 runBlocking {
                     dataStoreManager.androidAutoLikeInsteadOfPrevious.first() == DataStoreManager.TRUE
                 }
-            // AA now-playing is driven by the same platform/media-notification session as the
-            // phone notification, so the AA layout must be applied session-wide when enabled.
-            mediaSession?.setMediaButtonPreferences(
+            // AA now-playing shares the platform/media-notification session with the phone
+            // notification, so apply the AA layout session-wide when the setting is on.
+            session.setMediaButtonPreferences(
                 list.toMediaButtonPreferences(this, aaLikeEnabled),
+            )
+            // onConnect may have withheld SEEK_TO_PREVIOUS while the setting was on; restore
+            // or re-withhold it when the toggle changes so system Prev comes back when off.
+            val sessionCommands = sessionCommandsWithCustoms()
+            for (controller in session.connectedControllers) {
+                val playerCommandsBuilder =
+                    Player.Commands
+                        .Builder()
+                        .addAllCommands()
+                        .remove(COMMAND_GET_TIMELINE)
+                if (aaLikeEnabled && isCarOrPlatformController(session, controller)) {
+                    playerCommandsBuilder
+                        .remove(COMMAND_SEEK_TO_PREVIOUS)
+                        .remove(COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                }
+                session.setAvailableCommands(
+                    controller,
+                    sessionCommands,
+                    playerCommandsBuilder.build(),
+                )
+            }
+            Logger.w(
+                "Service",
+                "applyTransportLayout aaLike=$aaLikeEnabled controllers=${session.connectedControllers.size}",
             )
         }
 
         simpleMediaServiceHandler.onUpdateNotification = { list ->
-            applyMediaButtonPreferences(list)
+            applyTransportLayout(list)
+        }
+
+        // Re-apply layout/commands when the setting toggles (no reconnect required).
+        coroutineScope.launch {
+            dataStoreManager.androidAutoLikeInsteadOfPrevious
+                .distinctUntilChanged()
+                .collect {
+                    applyTransportLayout()
+                }
         }
 
         val sessionToken = SessionToken(this, ComponentName(this, SimpleMediaService::class.java))
@@ -182,7 +255,7 @@ internal class SimpleMediaService :
         }
 
         simpleMediaServiceHandler.onUpdateNotification = { list ->
-            applyMediaButtonPreferences(list)
+            applyTransportLayout(list)
         }
     }
 

--- a/media/media3/src/main/java/com/maxrave/media3/service/callback/SimpleMediaSessionCallback.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/callback/SimpleMediaSessionCallback.kt
@@ -2,8 +2,10 @@ package com.maxrave.media3.service.callback
 
 import android.content.ContentResolver
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.annotation.DrawableRes
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
@@ -12,8 +14,10 @@ import androidx.media3.common.Player
 import androidx.media3.common.Player.COMMAND_GET_TIMELINE
 import androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT
 import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS
+import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.CommandButton
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession
@@ -29,6 +33,8 @@ import com.maxrave.common.MEDIA_CUSTOM_COMMAND
 import com.maxrave.domain.data.entities.SongEntity
 import com.maxrave.domain.data.model.browse.album.Track
 import com.maxrave.domain.data.model.home.HomeItem
+import com.maxrave.domain.data.player.GenericCommandButton
+import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.mediaservice.handler.MediaPlayerHandler
 import com.maxrave.domain.mediaservice.handler.PlayerEvent
 import com.maxrave.domain.mediaservice.handler.PlaylistType
@@ -49,6 +55,7 @@ import com.maxrave.domain.utils.toSongEntity
 import com.maxrave.domain.utils.toTrack
 import com.maxrave.logger.Logger
 import com.maxrave.media3.R
+import com.maxrave.media3.extension.toMediaButtonPreferences
 import com.maxrave.media3.extension.toMediaItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,6 +65,7 @@ import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.guava.future
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 private const val TAG = "AndroidAuto"
 
@@ -66,6 +74,7 @@ internal class SimpleMediaSessionCallback(
     private val context: Context,
     private val scope: CoroutineScope,
     private val mediaPlayerHandler: MediaPlayerHandler,
+    private val dataStoreManager: DataStoreManager,
     private val searchRepository: SearchRepository,
     private val songRepository: SongRepository,
     private val localPlaylistRepository: LocalPlaylistRepository,
@@ -82,24 +91,56 @@ internal class SimpleMediaSessionCallback(
     private val searchTempList = mutableListOf<Track>()
     private val listHomeItem = mutableListOf<HomeItem>()
 
+    private fun isAaLikeInsteadOfPreviousEnabled(): Boolean =
+        runBlocking {
+            dataStoreManager.androidAutoLikeInsteadOfPrevious.first() == DataStoreManager.TRUE
+        }
+
+    private fun isCarOrPlatformMediaController(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+    ): Boolean =
+        session.isMediaNotificationController(controller) ||
+            session.isAutoCompanionController(controller) ||
+            session.isAutomotiveController(controller) ||
+            isAndroidAutoHost(controller.packageName)
+
+    private fun buildMediaButtonPreferences(aaLikeInsteadOfPrevious: Boolean): List<CommandButton> {
+        val control = mediaPlayerHandler.controlState.value
+        return listOf(
+            GenericCommandButton.Like(control.isLiked),
+            GenericCommandButton.Shuffle(isShuffled = control.isShuffle),
+            GenericCommandButton.Repeat(repeatState = control.repeatState),
+            GenericCommandButton.Radio,
+        ).toMediaButtonPreferences(context, aaLikeInsteadOfPrevious)
+    }
+
     override fun onConnect(
         session: MediaSession,
         controller: MediaSession.ControllerInfo,
     ): MediaSession.ConnectionResult {
-        Logger.w(TAG, "onConnect: ${controller.packageName}")
+        val aaLikeInsteadOfPrevious = isAaLikeInsteadOfPreviousEnabled()
+        val customizeForCar = isCarOrPlatformMediaController(session, controller)
+        Logger.w(
+            TAG,
+            "onConnect pkg=${controller.packageName} aaLike=$aaLikeInsteadOfPrevious " +
+                "carOrPlatform=$customizeForCar " +
+                "notif=${session.isMediaNotificationController(controller)} " +
+                "auto=${session.isAutoCompanionController(controller)}",
+        )
         val sessionCommands =
             MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
                 .buildUpon()
-                // Add custom commands
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.LIKE, Bundle()))
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.REPEAT, Bundle()))
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.RADIO, Bundle()))
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.SHUFFLE, Bundle()))
+                .add(SessionCommand(MEDIA_CUSTOM_COMMAND.PREVIOUS, Bundle()))
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.GET_PLATFORM_TOKEN, Bundle()))
                 .build()
         // Backup for MODE: when Gearhead rebinds after AA returns, resume only if we were
         // interrupted while playing (adapter also watches CarConnection).
-        if (isAndroidAutoHost(controller.packageName)) {
+        if (customizeForCar && !session.isMediaNotificationController(controller)) {
             scope.launch {
                 delay(500)
                 runCatching {
@@ -110,16 +151,72 @@ internal class SimpleMediaSessionCallback(
                 }
             }
         }
-        return MediaSession.ConnectionResult
-            .AcceptedResultBuilder(session)
-            .setAvailableSessionCommands(sessionCommands)
-            .setAvailablePlayerCommands(
-                Player.Commands
-                    .Builder()
-                    .addAllCommands()
-                    .remove(COMMAND_GET_TIMELINE)
-                    .build(),
-            ).build()
+
+        val playerCommandsBuilder =
+            Player.Commands
+                .Builder()
+                .addAllCommands()
+                .remove(COMMAND_GET_TIMELINE)
+        // Withhold system previous so Like in SLOT_BACK can occupy the compact back slot.
+        // Steering-wheel previous still arrives via onMediaButtonEvent / remapped seek.
+        if (aaLikeInsteadOfPrevious && customizeForCar) {
+            playerCommandsBuilder
+                .remove(COMMAND_SEEK_TO_PREVIOUS)
+                .remove(COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+        }
+
+        val resultBuilder =
+            MediaSession.ConnectionResult
+                .AcceptedResultBuilder(session)
+                .setAvailableSessionCommands(sessionCommands)
+                .setAvailablePlayerCommands(playerCommandsBuilder.build())
+
+        // Platform media notification + AA hosts share this session for transport UI.
+        if (aaLikeInsteadOfPrevious && customizeForCar) {
+            // Like in SLOT_BACK; custom Previous first in overflow (old Like spot).
+            resultBuilder.setMediaButtonPreferences(buildMediaButtonPreferences(true))
+        }
+        return resultBuilder.build()
+    }
+
+    /**
+     * Steering-wheel "previous" arrives as [KeyEvent.KEYCODE_MEDIA_PREVIOUS].
+     * Map it to like when the AA setting is on.
+     */
+    override fun onMediaButtonEvent(
+        session: MediaSession,
+        controllerInfo: MediaSession.ControllerInfo,
+        intent: Intent,
+    ): Boolean {
+        if (!isAaLikeInsteadOfPreviousEnabled() ||
+            !isCarOrPlatformMediaController(session, controllerInfo)
+        ) {
+            return super.onMediaButtonEvent(session, controllerInfo, intent)
+        }
+        val keyEvent =
+            if (android.os.Build.VERSION.SDK_INT >= 33) {
+                intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT, KeyEvent::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT) as? KeyEvent
+            }
+        if (keyEvent != null &&
+            keyEvent.action == KeyEvent.ACTION_DOWN &&
+            keyEvent.repeatCount == 0 &&
+            (
+                keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS ||
+                    keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_REWIND
+            )
+        ) {
+            Logger.w(
+                TAG,
+                "onMediaButtonEvent: mapping keyCode=${keyEvent.keyCode} from " +
+                    "${controllerInfo.packageName} → like",
+            )
+            toggleLike()
+            return true
+        }
+        return super.onMediaButtonEvent(session, controllerInfo, intent)
     }
 
     override fun onPlayerCommandRequest(
@@ -127,17 +224,29 @@ internal class SimpleMediaSessionCallback(
         controller: MediaSession.ControllerInfo,
         playerCommand: Int,
     ): Int {
-        Logger.w(TAG, "Player Command $playerCommand")
-        scope.launch {
-            when (playerCommand) {
-                COMMAND_SEEK_TO_NEXT -> {
+        Logger.w(TAG, "Player Command $playerCommand from ${controller.packageName}")
+        val remapPreviousToLike =
+            isAaLikeInsteadOfPreviousEnabled() &&
+                isCarOrPlatformMediaController(session, controller)
+        when (playerCommand) {
+            COMMAND_SEEK_TO_PREVIOUS, COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> {
+                if (remapPreviousToLike) {
+                    Logger.w(TAG, "Player previous → like (blocking seek)")
+                    toggleLike()
+                    return SessionResult.RESULT_INFO_SKIPPED
+                }
+            }
+            COMMAND_SEEK_TO_NEXT -> {
+                scope.launch {
                     mediaPlayerHandler.onPlayerEvent(PlayerEvent.Next)
                 }
-                COMMAND_SEEK_TO_PREVIOUS -> {
-                    mediaPlayerHandler.onPlayerEvent(PlayerEvent.Previous)
-                }
-                COMMAND_GET_TIMELINE -> {
-                }
+            }
+            COMMAND_GET_TIMELINE -> {
+            }
+        }
+        if (playerCommand == COMMAND_SEEK_TO_PREVIOUS && !remapPreviousToLike) {
+            scope.launch {
+                mediaPlayerHandler.onPlayerEvent(PlayerEvent.Previous)
             }
         }
         return super.onPlayerCommandRequest(session, controller, playerCommand)
@@ -153,6 +262,12 @@ internal class SimpleMediaSessionCallback(
         when (customCommand.customAction) {
             MEDIA_CUSTOM_COMMAND.LIKE -> {
                 toggleLike()
+            }
+
+            MEDIA_CUSTOM_COMMAND.PREVIOUS -> {
+                scope.launch {
+                    mediaPlayerHandler.onPlayerEvent(PlayerEvent.Previous)
+                }
             }
 
             MEDIA_CUSTOM_COMMAND.REPEAT -> {
@@ -331,6 +446,7 @@ internal class SimpleMediaSessionCallback(
                     }
 
                     FAVORITE -> {
+                        songRepository.syncYouTubeLikedToLocal(force = false)
                         songRepository
                             .getLikedSongs()
                             .first()
@@ -554,6 +670,7 @@ internal class SimpleMediaSessionCallback(
 
                 FAVORITE -> {
                     val songId = path.getOrNull(1) ?: return@future defaultResult
+                    songRepository.syncYouTubeLikedToLocal(force = false)
                     val likedSongs = songRepository.getLikedSongs().first()
                     if (likedSongs.isEmpty()) {
                         defaultResult

--- a/media/media3/src/main/java/com/maxrave/media3/service/callback/SimpleMediaSessionCallback.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/callback/SimpleMediaSessionCallback.kt
@@ -52,6 +52,7 @@ import com.maxrave.media3.R
 import com.maxrave.media3.extension.toMediaItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.lastOrNull
@@ -96,6 +97,19 @@ internal class SimpleMediaSessionCallback(
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.SHUFFLE, Bundle()))
                 .add(SessionCommand(MEDIA_CUSTOM_COMMAND.GET_PLATFORM_TOKEN, Bundle()))
                 .build()
+        // Backup for MODE: when Gearhead rebinds after AA returns, resume only if we were
+        // interrupted while playing (adapter also watches CarConnection).
+        if (isAndroidAutoHost(controller.packageName)) {
+            scope.launch {
+                delay(500)
+                runCatching {
+                    (mediaPlayerHandler.player as? com.maxrave.media3.exoplayer.CrossfadeExoPlayerAdapter)
+                        ?.resumeIfInterrupted()
+                }.onFailure {
+                    Logger.e(TAG, "AA resume failed: ${it.message}")
+                }
+            }
+        }
         return MediaSession.ConnectionResult
             .AcceptedResultBuilder(session)
             .setAvailableSessionCommands(sessionCommands)
@@ -508,7 +522,18 @@ internal class SimpleMediaSessionCallback(
             when (path.firstOrNull()) {
                 SONG -> {
                     val songId = path.getOrNull(1) ?: return@future defaultResult
-                    val firstQueue = songRepository.getSongById(songId).first()?.toTrack() ?: return@future defaultResult
+                    // Search results are shown from searchTempList but were never written to Room.
+                    // Looking up only via getSongById made AA search taps no-op for new songs,
+                    // so the previously playing track kept going (looked like the "wrong" song).
+                    val firstQueue =
+                        searchTempList.firstOrNull { it.videoId == songId }
+                            ?: songRepository.getSongById(songId).first()?.toTrack()
+                            ?: streamRepository.getFullMetadata(songId).lastOrNull()?.data
+                    if (firstQueue == null) {
+                        Logger.w(TAG, "onSetMediaItems SONG: no track for $songId")
+                        return@future defaultResult
+                    }
+                    Logger.w(TAG, "onSetMediaItems SONG: playing ${firstQueue.title} ($songId)")
                     mediaPlayerHandler.setQueueData(
                         QueueData.Data(
                             listTracks = arrayListOf(firstQueue),
@@ -816,5 +841,10 @@ internal class SimpleMediaSessionCallback(
         const val FAVORITE = "favorite"
         const val DOWNLOADED = "downloaded"
         const val MEDIA_SEARCH_SUPPORTED = "android.media.browse.SEARCH_SUPPORTED"
+
+        private fun isAndroidAutoHost(packageName: String): Boolean =
+            packageName == "com.google.android.projection.gearhead" ||
+                packageName.contains("projection", ignoreCase = true) ||
+                packageName.contains("gearhead", ignoreCase = true)
     }
 }

--- a/media/media3/src/main/res/values/strings.xml
+++ b/media/media3/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="repeat_all">Repeat All</string>
     <string name="repeat_off">Repeat Off</string>
     <string name="shuffle">Shuffle</string>
+    <string name="previous">Previous</string>
     <string name="notification_channel_name" translatable="false">SimpMusic Playback Notification</string>
     <string name="home">Home</string>
     <string name="search">Search</string>


### PR DESCRIPTION
## Summary
- Route MediaSession play/pause through the crossfade adapter so audio focus is requested before ExoPlayer starts (fixes Android Auto showing playing with silence).
- Arm playback resume across MODE/USB/radio audio source switches after transient focus loss.
- Resolve Android Auto search selections that are not yet in Room before starting playback.

## Test plan
- [ ] Connect Android Auto; start playback from the app, then from AA home — audio should play (not silent).
- [ ] While playing, switch audio source (e.g. MODE/USB/radio) and return — playback should resume when focus returns.
- [ ] Use AA voice/search to play a track not in local library — playback should start after resolve.
- [ ] Regression: normal phone playback, pause/resume, and Cast (if applicable) unchanged.