### PR TITLE
feat: podcast improvements

### DIFF
--- a/common/src/commonMain/kotlin/com/maxrave/common/Config.kt
+++ b/common/src/commonMain/kotlin/com/maxrave/common/Config.kt
@@ -551,7 +551,10 @@ const val TITLE = "TITLE"
 object MERGING_DATA_TYPE {
     const val SONG = "Song"
     const val VIDEO = "Video"
+    const val PODCAST = "Podcast"
 }
+
+const val PODCAST_PROGRESS_KEY_PREFIX = "podcast_progress_"
 
 enum class LibraryChipType {
     YOUR_LIBRARY,

--- a/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
+++ b/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
@@ -327,6 +327,19 @@ internal class MediaServiceHandlerImpl(
                         updateNotification()
                     }
                 }
+            val podcastSeekSettingsJob =
+                launch {
+                    combine(
+                        dataStoreManager.podcastRewindSeconds,
+                        dataStoreManager.podcastForwardSeconds,
+                    ) { rewind, forward ->
+                        rewind to forward
+                    }.distinctUntilChanged().collect {
+                        if (player.currentMediaItem?.isPodcast() == true) {
+                            updateNotification()
+                        }
+                    }
+                }
             val skipSegmentsJob =
                 launch {
                     simpleMediaState
@@ -469,6 +482,7 @@ internal class MediaServiceHandlerImpl(
                     }
                 }
             controlStateJob.join()
+            podcastSeekSettingsJob.join()
             skipSegmentsJob.join()
             playbackJob.join()
             playbackSpeedPitchJob.join()
@@ -796,13 +810,24 @@ internal class MediaServiceHandlerImpl(
                         ?.liked ?: false
                 Logger.w("Check liked", liked.toString())
                 _controlState.value = _controlState.value.copy(isLiked = liked)
+                val isPodcast = player.currentMediaItem?.isPodcast() == true
+                val podcastButtons =
+                    if (isPodcast) {
+                        listOf(
+                            GenericCommandButton.SeekBack(dataStoreManager.podcastRewindSeconds.first()),
+                            GenericCommandButton.SeekForward(dataStoreManager.podcastForwardSeconds.first()),
+                        )
+                    } else {
+                        emptyList()
+                    }
                 onUpdateNotification.invoke(
-                    listOf(
-                        GenericCommandButton.Like(liked),
-                        GenericCommandButton.Shuffle(isShuffled = _controlState.value.isShuffle),
-                        GenericCommandButton.Repeat(repeatState = _controlState.value.repeatState),
-                        GenericCommandButton.Radio,
-                    ),
+                    podcastButtons +
+                        listOf(
+                            GenericCommandButton.Like(liked),
+                            GenericCommandButton.Shuffle(isShuffled = _controlState.value.isShuffle),
+                            GenericCommandButton.Repeat(repeatState = _controlState.value.repeatState),
+                            GenericCommandButton.Radio,
+                        ),
                 )
             }
     }

--- a/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
+++ b/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
@@ -404,14 +404,25 @@ internal class MediaServiceHandlerImpl(
                 }
             val playbackSpeedPitchJob =
                 launch {
-                    combine(dataStoreManager.playbackSpeed, dataStoreManager.pitch) { speed, pitch ->
-                        Pair(speed, pitch)
-                    }.collectLatest { pair ->
-                        Logger.w(TAG, "Playback speed: ${pair.first}, Pitch: ${pair.second}")
+                    combine(
+                        combine(dataStoreManager.playbackSpeed, dataStoreManager.pitch) { speed, pitch -> speed to pitch },
+                        combine(dataStoreManager.podcastPlaybackSpeed, dataStoreManager.podcastPitch) { speed, pitch -> speed to pitch },
+                        combine(nowPlaying, dataStoreManager.crossfadeEnabled) { mediaItem, crossfade ->
+                            (mediaItem?.isPodcast() == true) to (crossfade == TRUE)
+                        },
+                    ) { music, podcast, playbackContext ->
+                        val (isPodcast, crossfadeEnabled) = playbackContext
+                        when {
+                            isPodcast -> podcast
+                            crossfadeEnabled -> 1f to 0
+                            else -> music
+                        }
+                    }.distinctUntilChanged().collectLatest { (speed, pitch) ->
+                        Logger.w(TAG, "Playback speed: $speed, Pitch: $pitch")
                         player.playbackParameters =
                             GenericPlaybackParameters(
-                                pair.first,
-                                2f.pow(pair.second.toFloat() / 12),
+                                speed,
+                                2f.pow(pitch.toFloat() / 12),
                             )
                         Logger.w(TAG, "Playback current speed: ${player.playbackParameters.speed}, Pitch: ${player.playbackParameters.pitch}")
                         // A speed change shifts the RPC start/end timestamps (Discord renders the bar
@@ -2633,12 +2644,11 @@ internal class MediaServiceHandlerImpl(
                     song = song,
                     progressMs = getProgress(),
                     durationMs = getPlayerDuration(),
-                    speed = dataStoreManager.playbackSpeed.first(),
+                    speed = player.playbackParameters.speed,
                     seq = seq,
                 )
-            // Compare-and-keep-newest: the playbackSpeed.first() suspend above means two calls to
-            // updateDiscordRpc() can interleave and resolve out of order, so a plain `.value = ...`
-            // write could let an older call clobber a newer one. Keep whichever has the higher seq.
+            // Keep whichever snapshot has the higher event sequence so a delayed older update
+            // cannot overwrite the latest playback state.
             rpcSnapshotFlow.update { cur -> if (cur == null || seq >= cur.seq) snapshot else cur }
         }
     }

--- a/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
+++ b/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
@@ -884,6 +884,11 @@ internal class MediaServiceHandlerImpl(
                 player.seekForward()
             }
 
+            is PlayerEvent.SeekBy -> {
+                val endPosition = player.duration.takeIf { it > 0L } ?: Long.MAX_VALUE
+                player.seekTo((player.currentPosition + playerEvent.offsetMs).coerceIn(0L, endPosition))
+            }
+
             PlayerEvent.PlayPause -> {
                 if (player.isPlaying) {
                     player.pause()

--- a/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
+++ b/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
@@ -2199,6 +2199,7 @@ internal class MediaServiceHandlerImpl(
             normalizeVolume = dataStoreManager.normalizeVolume.first() == TRUE
         }
         val isPodcast = player.currentMediaItem?.isPodcast() == true
+        val audioSessionId = player.audioSessionId
         if (!normalizeVolume && !isPodcast) {
             loudnessEnhancer?.enabled = false
             loudnessEnhancer?.release()
@@ -2213,13 +2214,14 @@ internal class MediaServiceHandlerImpl(
         // The old LoudnessEnhancer becomes attached to a released session and has no effect.
         // Skip entirely while casting: a Cast session has no local audio session, and
         // constructing a LoudnessEnhancer with session id 0 (AUDIO_SESSION_ID_UNSET) throws.
-        if (!_castState.value.isRemote && player.audioSessionId != PlayerConstants.AUDIO_SESSION_ID_UNSET) {
+        if (!_castState.value.isRemote && audioSessionId != PlayerConstants.AUDIO_SESSION_ID_UNSET) {
             try {
                 loudnessEnhancer?.release()
             } catch (_: Exception) {
             }
             try {
-                loudnessEnhancer = LoudnessEnhancer(player.audioSessionId)
+                loudnessEnhancer = LoudnessEnhancer(audioSessionId)
+                Logger.d(TAG, "LoudnessEnhancer attached to active session $audioSessionId")
             } catch (e: Exception) {
                 Logger.e(TAG, "mayBeNormalizeVolume: ${e.message}")
                 e.printStackTrace()
@@ -2491,6 +2493,18 @@ internal class MediaServiceHandlerImpl(
         }
     }
 
+    override fun onAudioSessionIdChanged(audioSessionId: Int) {
+        if (audioSessionId == PlayerConstants.AUDIO_SESSION_ID_UNSET || _castState.value.isRemote) return
+        coroutineScope.launch {
+            if (player.audioSessionId != audioSessionId) return@launch
+            Logger.d(
+                TAG,
+                "Active audio session ready: $audioSessionId, podcast=${player.currentMediaItem?.isPodcast() == true}",
+            )
+            mayBeNormalizeVolume()
+        }
+    }
+
     override fun onMediaItemTransition(
         mediaItem: GenericMediaItem?,
         reason: Int,
@@ -2505,7 +2519,6 @@ internal class MediaServiceHandlerImpl(
             mayBeSavePodcastPosition(nowPlayingState.value.mediaItem, currentState.progress)
         }
         Logger.w(TAG, "Smooth Switching Transition Current Position: ${player.currentPosition}")
-        mayBeNormalizeVolume()
         Logger.w(TAG, "REASON onMediaItemTransition: $reason")
         Logger.d(TAG, "Media Item Transition Media Item: ${mediaItem?.metadata?.title}")
         if (mediaItem?.mediaId != _nowPlaying.value?.mediaId) {

--- a/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
+++ b/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
@@ -203,6 +203,7 @@ internal class MediaServiceHandlerImpl(
 
     private var skipSilent = false
 
+    @Volatile
     private var normalizeVolume = false
 
     private var watchTimeList: ArrayList<Float> = arrayListOf()
@@ -289,8 +290,6 @@ internal class MediaServiceHandlerImpl(
         getFormatJob = Job()
         jobWatchtime = Job()
         skipSilent = runBlocking { dataStoreManager.skipSilent.first() == TRUE }
-        normalizeVolume =
-            runBlocking { dataStoreManager.normalizeVolume.first() == TRUE }
         _nowPlaying.value = player.currentMediaItem
         if (runBlocking { dataStoreManager.saveStateOfPlayback.first() } == TRUE) {
             Logger.d(TAG, "SaveStateOfPlayback TRUE")
@@ -338,6 +337,13 @@ internal class MediaServiceHandlerImpl(
                         if (player.currentMediaItem?.isPodcast() == true) {
                             updateNotification()
                         }
+                    }
+                }
+            val normalizeVolumeSettingJob =
+                launch {
+                    dataStoreManager.normalizeVolume.distinctUntilChanged().collectLatest { enabled ->
+                        normalizeVolume = enabled == TRUE
+                        mayBeNormalizeVolume()
                     }
                 }
             val skipSegmentsJob =
@@ -483,6 +489,7 @@ internal class MediaServiceHandlerImpl(
                 }
             controlStateJob.join()
             podcastSeekSettingsJob.join()
+            normalizeVolumeSettingJob.join()
             skipSegmentsJob.join()
             playbackJob.join()
             playbackSpeedPitchJob.join()
@@ -2220,9 +2227,6 @@ internal class MediaServiceHandlerImpl(
     }
 
     override fun mayBeNormalizeVolume() {
-        runBlocking {
-            normalizeVolume = dataStoreManager.normalizeVolume.first() == TRUE
-        }
         val isPodcast = player.currentMediaItem?.isPodcast() == true
         val audioSessionId = player.audioSessionId
         if (!normalizeVolume && !isPodcast) {

--- a/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
+++ b/data/src/androidMain/kotlin/com/maxrave/data/mediaservice/MediaServiceHandlerImpl.kt
@@ -20,6 +20,7 @@ import com.maxrave.common.DESC
 import com.maxrave.common.LOCAL_PLAYLIST_ID
 import com.maxrave.common.LOCAL_PLAYLIST_ID_SAVED_QUEUE
 import com.maxrave.common.MERGING_DATA_TYPE
+import com.maxrave.common.PODCAST_PROGRESS_KEY_PREFIX
 import com.maxrave.common.TITLE
 import com.maxrave.data.db.Converters
 import com.maxrave.data.lastfm.LastfmScrobbler
@@ -38,6 +39,7 @@ import com.maxrave.domain.data.player.GenericTracks
 import com.maxrave.domain.data.player.PlayerConstants
 import com.maxrave.domain.data.player.PlayerError
 import com.maxrave.domain.extension.isVideo
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.extension.now
 import com.maxrave.domain.extension.toGenericMediaItem
 import com.maxrave.domain.extension.toSongEntity
@@ -216,6 +218,8 @@ internal class MediaServiceHandlerImpl(
     private var progressJob: Job? = null
 
     private var bufferedJob: Job? = null
+
+    private var podcastResumeJob: Job? = null
 
     private var updateNotificationJob: Job? = null
 
@@ -720,9 +724,18 @@ internal class MediaServiceHandlerImpl(
         mediaItem: GenericMediaItem,
         index: Int? = null,
     ) {
+        val queueTrack = queueData.value.data.listTracks.find { it.videoId == mediaItem.mediaId }
+        val item =
+            if (queueData.value.isPodcast() || queueTrack?.isPodcast() == true) {
+                mediaItem.copy(
+                    metadata = mediaItem.metadata.copy(description = MERGING_DATA_TYPE.PODCAST),
+                )
+            } else {
+                mediaItem
+            }
         index?.let {
-            player.addMediaItem(it, mediaItem)
-        } ?: player.addMediaItem(mediaItem)
+            player.addMediaItem(it, item)
+        } ?: player.addMediaItem(item)
         if (player.mediaItemCount == 1) {
             player.prepare()
             player.playWhenReady = true
@@ -816,6 +829,7 @@ internal class MediaServiceHandlerImpl(
                     if (sinceLastPositionSaveMs >= positionPersistIntervalMs) {
                         sinceLastPositionSaveMs = 0
                         mayBeSaveRecentPosition()
+                        mayBeSavePodcastPosition()
                         // Riding the existing 5s tick instead of adding one: the scrobble point is
                         // half the track or four minutes, so five seconds of granularity is plenty
                         // and the 100ms loop stays as cheap as it was.
@@ -2128,11 +2142,59 @@ internal class MediaServiceHandlerImpl(
         }
     }
 
+    private fun mayBeSavePodcastPosition(
+        mediaItem: GenericMediaItem? = player.currentMediaItem,
+        position: Long = player.contentPosition,
+    ) {
+        if (mediaItem?.isPodcast() != true || position < 0L) return
+        coroutineScope.launch {
+            dataStoreManager.putString(
+                "$PODCAST_PROGRESS_KEY_PREFIX${mediaItem.mediaId}",
+                position.toString(),
+            )
+        }
+    }
+
+    private fun clearPodcastPosition(mediaItem: GenericMediaItem?) {
+        if (mediaItem?.isPodcast() != true) return
+        coroutineScope.launch {
+            dataStoreManager.putString("$PODCAST_PROGRESS_KEY_PREFIX${mediaItem.mediaId}", "0")
+        }
+    }
+
+    private fun restorePodcastPosition(mediaItem: GenericMediaItem) {
+        podcastResumeJob?.cancel()
+        if (!mediaItem.isPodcast()) return
+        podcastResumeJob =
+            coroutineScope.launch {
+                val savedPosition =
+                    dataStoreManager
+                        .getString("$PODCAST_PROGRESS_KEY_PREFIX${mediaItem.mediaId}")
+                        .first()
+                        ?.toLongOrNull()
+                        ?: return@launch
+                if (savedPosition < 5_000L) return@launch
+
+                repeat(150) {
+                    if (player.currentMediaItem?.mediaId != mediaItem.mediaId) return@launch
+                    val duration = player.duration
+                    if (duration > 0L) {
+                        if (savedPosition < duration - 10_000L && player.currentPosition < 5_000L) {
+                            player.seekTo(savedPosition)
+                        }
+                        return@launch
+                    }
+                    delay(100)
+                }
+            }
+    }
+
     override fun mayBeNormalizeVolume() {
         runBlocking {
             normalizeVolume = dataStoreManager.normalizeVolume.first() == TRUE
         }
-        if (!normalizeVolume) {
+        val isPodcast = player.currentMediaItem?.isPodcast() == true
+        if (!normalizeVolume && !isPodcast) {
             loudnessEnhancer?.enabled = false
             loudnessEnhancer?.release()
             loudnessEnhancer = null
@@ -2184,9 +2246,15 @@ internal class MediaServiceHandlerImpl(
                                             it
                                         }
                                     }
+                                val targetGainMb =
+                                    if (isPodcast) {
+                                        maxOf(400, 0f.toMb() - loudnessMb)
+                                    } else {
+                                        0f.toMb() - loudnessMb
+                                    }
                                 Logger.d(TAG, "Loudness: ${format.loudnessDb} db, $loudnessMb")
                                 try {
-                                    loudnessEnhancer?.setTargetGain(0f.toMb() - loudnessMb)
+                                    loudnessEnhancer?.setTargetGain(targetGainMb)
                                     loudnessEnhancer?.enabled = true
                                     Logger.w(
                                         TAG,
@@ -2197,7 +2265,7 @@ internal class MediaServiceHandlerImpl(
                                     e.printStackTrace()
                                 }
                                 try {
-                                    secondLoudnessEnhancer?.setTargetGain(0f.toMb() - loudnessMb)
+                                    secondLoudnessEnhancer?.setTargetGain(targetGainMb)
                                     secondLoudnessEnhancer?.enabled = true
                                     Logger.w(
                                         TAG,
@@ -2313,6 +2381,8 @@ internal class MediaServiceHandlerImpl(
             progressJob = null
             bufferedJob?.cancel()
             bufferedJob = null
+            podcastResumeJob?.cancel()
+            podcastResumeJob = null
             sleepTimerJob?.cancel()
             sleepTimerJob = null
             volumeNormalizationJob?.cancel()
@@ -2370,6 +2440,7 @@ internal class MediaServiceHandlerImpl(
             }
 
             PlayerConstants.STATE_ENDED -> {
+                clearPodcastPosition(player.currentMediaItem)
                 _simpleMediaState.value = SimpleMediaState.Ended
                 Logger.d(TAG, "onPlaybackStateChanged: Ended")
             }
@@ -2396,6 +2467,9 @@ internal class MediaServiceHandlerImpl(
         } else {
             stopProgressUpdate()
             mayBeSaveRecentSong()
+            if (player.playbackState != PlayerConstants.STATE_ENDED) {
+                mayBeSavePodcastPosition()
+            }
             mayBeSavePlaybackState()
             if (discordRPC?.isRpcRunning() == true) {
                 discordRPC?.closeRPC()
@@ -2422,6 +2496,9 @@ internal class MediaServiceHandlerImpl(
         if (currentState is SimpleMediaState.Progress && lastPlayed != null && lastPlayed.durationSeconds > 0) {
             mayBeTrackingListeningLocal(lastPlayed, currentState.progress)
         }
+        if (currentState is SimpleMediaState.Progress && lastPlayed?.isPodcast() == true) {
+            mayBeSavePodcastPosition(nowPlayingState.value.mediaItem, currentState.progress)
+        }
         Logger.w(TAG, "Smooth Switching Transition Current Position: ${player.currentPosition}")
         mayBeNormalizeVolume()
         Logger.w(TAG, "REASON onMediaItemTransition: $reason")
@@ -2433,6 +2510,7 @@ internal class MediaServiceHandlerImpl(
             Logger.w(TAG, "onMediaItemTransition: ${mediaItem?.mediaId}")
             if (mediaItem != null) {
                 getDataOfNowPlayingState(mediaItem)
+                restorePodcastPosition(mediaItem)
             } else {
                 _nowPlayingState.update {
                     NowPlayingTrackState

--- a/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
@@ -990,6 +990,19 @@ internal class DataStoreManagerImpl(
         }
     }
 
+    override val podcastPlaybackSpeed =
+        settingsDataStore.data.map { preferences ->
+            preferences[PODCAST_PLAYBACK_SPEED] ?: 1.0f
+        }
+
+    override suspend fun setPodcastPlaybackSpeed(speed: Float) {
+        withContext(Dispatchers.IO) {
+            settingsDataStore.edit { settings ->
+                settings[PODCAST_PLAYBACK_SPEED] = speed
+            }
+        }
+    }
+
     override val podcastRewindSeconds =
         settingsDataStore.data.map { preferences ->
             DataStoreManager.normalizePodcastSeekSeconds(
@@ -1029,6 +1042,19 @@ internal class DataStoreManagerImpl(
         runBlocking {
             settingsDataStore.edit { settings ->
                 settings[PITCH] = pitch
+            }
+        }
+    }
+
+    override val podcastPitch =
+        settingsDataStore.data.map { preferences ->
+            preferences[PODCAST_PITCH] ?: 0
+        }
+
+    override suspend fun setPodcastPitch(pitch: Int) {
+        withContext(Dispatchers.IO) {
+            settingsDataStore.edit { settings ->
+                settings[PODCAST_PITCH] = pitch
             }
         }
     }
@@ -1574,9 +1600,11 @@ internal class DataStoreManagerImpl(
         val AUTO_CHECK_FOR_UPDATES = stringPreferencesKey("auto_check_for_updates")
         val UPDATE_CHANNEL = stringPreferencesKey("update_channel")
         val PLAYBACK_SPEED = floatPreferencesKey("playback_speed")
+        val PODCAST_PLAYBACK_SPEED = floatPreferencesKey("podcast_playback_speed")
         val PODCAST_REWIND_SECONDS = intPreferencesKey("podcast_rewind_seconds")
         val PODCAST_FORWARD_SECONDS = intPreferencesKey("podcast_forward_seconds")
         val PITCH = intPreferencesKey("pitch")
+        val PODCAST_PITCH = intPreferencesKey("podcast_pitch")
         val OPEN_APP_TIME = intPreferencesKey("open_app_time")
         val DATA_SYNC_ID = stringPreferencesKey("data_sync_id")
         val VISITOR_DATA = stringPreferencesKey("visitor_data")

--- a/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
@@ -990,6 +990,36 @@ internal class DataStoreManagerImpl(
         }
     }
 
+    override val podcastRewindSeconds =
+        settingsDataStore.data.map { preferences ->
+            DataStoreManager.normalizePodcastSeekSeconds(
+                preferences[PODCAST_REWIND_SECONDS] ?: DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS,
+            )
+        }
+
+    override suspend fun setPodcastRewindSeconds(seconds: Int) {
+        withContext(Dispatchers.IO) {
+            settingsDataStore.edit { settings ->
+                settings[PODCAST_REWIND_SECONDS] = DataStoreManager.normalizePodcastSeekSeconds(seconds)
+            }
+        }
+    }
+
+    override val podcastForwardSeconds =
+        settingsDataStore.data.map { preferences ->
+            DataStoreManager.normalizePodcastSeekSeconds(
+                preferences[PODCAST_FORWARD_SECONDS] ?: DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS,
+            )
+        }
+
+    override suspend fun setPodcastForwardSeconds(seconds: Int) {
+        withContext(Dispatchers.IO) {
+            settingsDataStore.edit { settings ->
+                settings[PODCAST_FORWARD_SECONDS] = DataStoreManager.normalizePodcastSeekSeconds(seconds)
+            }
+        }
+    }
+
     override val pitch =
         settingsDataStore.data.map { preferences ->
             preferences[PITCH] ?: 0
@@ -1544,6 +1574,8 @@ internal class DataStoreManagerImpl(
         val AUTO_CHECK_FOR_UPDATES = stringPreferencesKey("auto_check_for_updates")
         val UPDATE_CHANNEL = stringPreferencesKey("update_channel")
         val PLAYBACK_SPEED = floatPreferencesKey("playback_speed")
+        val PODCAST_REWIND_SECONDS = intPreferencesKey("podcast_rewind_seconds")
+        val PODCAST_FORWARD_SECONDS = intPreferencesKey("podcast_forward_seconds")
         val PITCH = intPreferencesKey("pitch")
         val OPEN_APP_TIME = intPreferencesKey("open_app_time")
         val DATA_SYNC_ID = stringPreferencesKey("data_sync_id")

--- a/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
+++ b/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
@@ -445,14 +445,25 @@ class JvmMediaPlayerHandlerImpl(
                 }
             val playbackSpeedPitchJob =
                 launch {
-                    combine(dataStoreManager.playbackSpeed, dataStoreManager.pitch) { speed, pitch ->
-                        Pair(speed, pitch)
-                    }.distinctUntilChanged().collectLatest { pair ->
-                        Logger.w(TAG, "Playback speed: ${pair.first}, Pitch: ${pair.second}")
+                    combine(
+                        combine(dataStoreManager.playbackSpeed, dataStoreManager.pitch) { speed, pitch -> speed to pitch },
+                        combine(dataStoreManager.podcastPlaybackSpeed, dataStoreManager.podcastPitch) { speed, pitch -> speed to pitch },
+                        combine(nowPlaying, dataStoreManager.crossfadeEnabled) { mediaItem, crossfade ->
+                            (mediaItem?.isPodcast() == true) to (crossfade == TRUE)
+                        },
+                    ) { music, podcast, playbackContext ->
+                        val (isPodcast, crossfadeEnabled) = playbackContext
+                        when {
+                            isPodcast -> podcast
+                            crossfadeEnabled -> 1f to 0
+                            else -> music
+                        }
+                    }.distinctUntilChanged().collectLatest { (speed, pitch) ->
+                        Logger.w(TAG, "Playback speed: $speed, Pitch: $pitch")
                         player.playbackParameters =
                             GenericPlaybackParameters(
-                                pair.first,
-                                2f.pow(pair.second.toFloat() / 12),
+                                speed,
+                                2f.pow(pitch.toFloat() / 12),
                             )
                         Logger.w(TAG, "Playback current speed: ${player.playbackParameters.speed}, Pitch: ${player.playbackParameters.pitch}")
                         // A speed change shifts the RPC start/end timestamps (Discord renders the bar
@@ -2661,12 +2672,11 @@ class JvmMediaPlayerHandlerImpl(
                     song = song,
                     progressMs = getProgress(),
                     durationMs = getPlayerDuration(),
-                    speed = dataStoreManager.playbackSpeed.first(),
+                    speed = player.playbackParameters.speed,
                     seq = seq,
                 )
-            // Compare-and-keep-newest: the playbackSpeed.first() suspend above means two calls to
-            // updateDiscordRpc() can interleave and resolve out of order, so a plain `.value = ...`
-            // write could let an older call clobber a newer one. Keep whichever has the higher seq.
+            // Keep whichever snapshot has the higher event sequence so a delayed older update
+            // cannot overwrite the latest playback state.
             rpcSnapshotFlow.update { cur -> if (cur == null || seq >= cur.seq) snapshot else cur }
         }
     }

--- a/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
+++ b/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
@@ -13,6 +13,7 @@ import com.maxrave.common.DESC
 import com.maxrave.common.LOCAL_PLAYLIST_ID
 import com.maxrave.common.LOCAL_PLAYLIST_ID_SAVED_QUEUE
 import com.maxrave.common.MERGING_DATA_TYPE
+import com.maxrave.common.PODCAST_PROGRESS_KEY_PREFIX
 import com.maxrave.common.TITLE
 import com.maxrave.data.db.Converters
 import com.maxrave.data.lastfm.LastfmScrobbler
@@ -34,6 +35,7 @@ import com.maxrave.domain.data.player.GenericTracks
 import com.maxrave.domain.data.player.PlayerConstants
 import com.maxrave.domain.data.player.PlayerError
 import com.maxrave.domain.extension.isVideo
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.extension.now
 import com.maxrave.domain.extension.toGenericMediaItem
 import com.maxrave.domain.extension.toSongEntity
@@ -246,6 +248,8 @@ class JvmMediaPlayerHandlerImpl(
     private var progressJob: Job? = null
 
     private var bufferedJob: Job? = null
+
+    private var podcastResumeJob: Job? = null
 
     private var updateNotificationJob: Job? = null
 
@@ -789,9 +793,18 @@ class JvmMediaPlayerHandlerImpl(
         mediaItem: GenericMediaItem,
         index: Int? = null,
     ) {
+        val queueTrack = queueData.value.data.listTracks.find { it.videoId == mediaItem.mediaId }
+        val item =
+            if (queueData.value.isPodcast() || queueTrack?.isPodcast() == true) {
+                mediaItem.copy(
+                    metadata = mediaItem.metadata.copy(description = MERGING_DATA_TYPE.PODCAST),
+                )
+            } else {
+                mediaItem
+            }
         index?.let {
-            player.addMediaItem(it, mediaItem)
-        } ?: player.addMediaItem(mediaItem)
+            player.addMediaItem(it, item)
+        } ?: player.addMediaItem(item)
         if (player.mediaItemCount == 1) {
             player.prepare()
             player.playWhenReady = true
@@ -875,6 +888,7 @@ class JvmMediaPlayerHandlerImpl(
                     if (sinceLastPositionSaveMs >= positionPersistIntervalMs) {
                         sinceLastPositionSaveMs = 0
                         mayBeSaveRecentPosition()
+                        mayBeSavePodcastPosition()
                         // Riding the existing 5s tick instead of adding one: the scrobble point is
                         // half the track or four minutes, so five seconds of granularity is plenty
                         // and the 100ms loop stays as cheap as it was.
@@ -2207,6 +2221,53 @@ class JvmMediaPlayerHandlerImpl(
         }
     }
 
+    private fun mayBeSavePodcastPosition(
+        mediaItem: GenericMediaItem? = player.currentMediaItem,
+        position: Long = player.contentPosition,
+    ) {
+        if (mediaItem?.isPodcast() != true || position < 0L) return
+        coroutineScope.launch {
+            dataStoreManager.putString(
+                "$PODCAST_PROGRESS_KEY_PREFIX${mediaItem.mediaId}",
+                position.toString(),
+            )
+        }
+    }
+
+    private fun clearPodcastPosition(mediaItem: GenericMediaItem?) {
+        if (mediaItem?.isPodcast() != true) return
+        coroutineScope.launch {
+            dataStoreManager.putString("$PODCAST_PROGRESS_KEY_PREFIX${mediaItem.mediaId}", "0")
+        }
+    }
+
+    private fun restorePodcastPosition(mediaItem: GenericMediaItem) {
+        podcastResumeJob?.cancel()
+        if (!mediaItem.isPodcast()) return
+        podcastResumeJob =
+            coroutineScope.launch {
+                val savedPosition =
+                    dataStoreManager
+                        .getString("$PODCAST_PROGRESS_KEY_PREFIX${mediaItem.mediaId}")
+                        .first()
+                        ?.toLongOrNull()
+                        ?: return@launch
+                if (savedPosition < 5_000L) return@launch
+
+                repeat(150) {
+                    if (player.currentMediaItem?.mediaId != mediaItem.mediaId) return@launch
+                    val duration = player.duration
+                    if (duration > 0L) {
+                        if (savedPosition < duration - 10_000L && player.currentPosition < 5_000L) {
+                            player.seekTo(savedPosition)
+                        }
+                        return@launch
+                    }
+                    delay(100)
+                }
+            }
+    }
+
     override fun mayBeNormalizeVolume() {
 //        runBlocking {
 //            normalizeVolume = dataStoreManager.normalizeVolume.first() == TRUE
@@ -2385,6 +2446,8 @@ class JvmMediaPlayerHandlerImpl(
             progressJob = null
             bufferedJob?.cancel()
             bufferedJob = null
+            podcastResumeJob?.cancel()
+            podcastResumeJob = null
             sleepTimerJob?.cancel()
             sleepTimerJob = null
             volumeNormalizationJob?.cancel()
@@ -2451,6 +2514,7 @@ class JvmMediaPlayerHandlerImpl(
             }
 
             PlayerConstants.STATE_ENDED -> {
+                clearPodcastPosition(player.currentMediaItem)
                 _simpleMediaState.value = SimpleMediaState.Ended
                 Logger.d(TAG, "onPlaybackStateChanged: Ended")
             }
@@ -2477,6 +2541,9 @@ class JvmMediaPlayerHandlerImpl(
         } else {
             stopProgressUpdate()
             mayBeSaveRecentSong()
+            if (player.playbackState != PlayerConstants.STATE_ENDED) {
+                mayBeSavePodcastPosition()
+            }
             mayBeSavePlaybackState()
             if (discordRPC?.isRpcRunning() == true) {
                 discordRPC?.closeRPC()
@@ -2496,6 +2563,9 @@ class JvmMediaPlayerHandlerImpl(
         if (currentState is SimpleMediaState.Progress && lastPlayed != null && lastPlayed.durationSeconds > 0) {
             mayBeTrackingListeningLocal(lastPlayed, currentState.progress)
         }
+        if (currentState is SimpleMediaState.Progress && lastPlayed?.isPodcast() == true) {
+            mayBeSavePodcastPosition(nowPlayingState.value.mediaItem, currentState.progress)
+        }
         Logger.w(TAG, "Smooth Switching Transition Current Position: ${player.currentPosition}")
         mayBeNormalizeVolume()
         Logger.w(TAG, "REASON onMediaItemTransition: $reason")
@@ -2507,6 +2577,7 @@ class JvmMediaPlayerHandlerImpl(
             Logger.w(TAG, "onMediaItemTransition: ${mediaItem?.mediaId}")
             if (mediaItem != null) {
                 getDataOfNowPlayingState(mediaItem)
+                restorePodcastPosition(mediaItem)
             } else {
                 _nowPlayingState.update {
                     NowPlayingTrackState

--- a/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
+++ b/data/src/jvmMain/kotlin/com/maxrave/data/mediaservice/JvmMediaPlayerHandlerImpl.kt
@@ -957,6 +957,14 @@ class JvmMediaPlayerHandlerImpl(
                 }
             }
 
+            is PlayerEvent.SeekBy -> {
+                val endPosition = player.duration.takeIf { it > 0L } ?: Long.MAX_VALUE
+                player.seekTo((player.currentPosition + playerEvent.offsetMs).coerceIn(0L, endPosition))
+                if (player.isPlaying) {
+                    nowPlayingState.value.songEntity?.let { updateDiscordRpc(it) }
+                }
+            }
+
             PlayerEvent.PlayPause -> {
                 if (player.isPlaying) {
                     stopProgressUpdate()

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/data/player/GenericCommandButton.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/data/player/GenericCommandButton.kt
@@ -15,5 +15,13 @@ sealed class GenericCommandButton {
         val repeatState: RepeatState,
     ) : GenericCommandButton()
 
+    data class SeekBack(
+        val seconds: Int,
+    ) : GenericCommandButton()
+
+    data class SeekForward(
+        val seconds: Int,
+    ) : GenericCommandButton()
+
     data object Radio : GenericCommandButton()
 }

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/extension/AllExt.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/extension/AllExt.kt
@@ -46,6 +46,18 @@ fun GenericMediaItem.isSong(): Boolean = this.metadata.description?.contains(MER
 
 fun GenericMediaItem.isVideo(): Boolean = this.metadata.description?.contains(MERGING_DATA_TYPE.VIDEO) == true
 
+fun GenericMediaItem.isPodcast(): Boolean = this.metadata.description?.contains(MERGING_DATA_TYPE.PODCAST) == true
+
+fun Track.isPodcast(): Boolean =
+    category.equals(MERGING_DATA_TYPE.PODCAST, ignoreCase = true) ||
+        videoType.equals(MERGING_DATA_TYPE.PODCAST, ignoreCase = true) ||
+        resultType.equals(MERGING_DATA_TYPE.PODCAST, ignoreCase = true)
+
+fun SongEntity.isPodcast(): Boolean =
+    category.equals(MERGING_DATA_TYPE.PODCAST, ignoreCase = true) ||
+        videoType.equals(MERGING_DATA_TYPE.PODCAST, ignoreCase = true) ||
+        resultType.equals(MERGING_DATA_TYPE.PODCAST, ignoreCase = true)
+
 fun GenericMediaItem.toSongEntity(): SongEntity =
     SongEntity(
         videoId = this.mediaId,
@@ -60,9 +72,9 @@ fun GenericMediaItem.toSongEntity(): SongEntity =
         likeStatus = "INDIFFERENT",
         thumbnails = this.metadata.artworkUri.toString(),
         title = this.metadata.title.toString(),
-        videoType = "",
-        category = "",
-        resultType = "",
+        videoType = if (isPodcast()) MERGING_DATA_TYPE.PODCAST else "",
+        category = if (isPodcast()) MERGING_DATA_TYPE.PODCAST else "",
+        resultType = if (isPodcast()) MERGING_DATA_TYPE.PODCAST else "",
         liked = false,
         totalPlayTime = 0,
         downloadState = 0,
@@ -79,7 +91,12 @@ fun SongEntity.toGenericMediaItem(): GenericMediaItem {
                 artist = this.artistName?.connectArtists(),
                 albumTitle = this.albumName,
                 artworkUri = this.thumbnails,
-                description = if (isSong) MERGING_DATA_TYPE.SONG else MERGING_DATA_TYPE.VIDEO,
+                description =
+                    when {
+                        isPodcast() -> MERGING_DATA_TYPE.PODCAST
+                        isSong -> MERGING_DATA_TYPE.SONG
+                        else -> MERGING_DATA_TYPE.VIDEO
+                    },
             ),
         customCacheKey = this.videoId,
     )
@@ -109,7 +126,12 @@ fun Track.toGenericMediaItem(): GenericMediaItem {
                 artist = artistName,
                 albumTitle = this.album?.name,
                 artworkUri = thumbUrl,
-                description = if (isSong) MERGING_DATA_TYPE.SONG else MERGING_DATA_TYPE.VIDEO,
+                description =
+                    when {
+                        isPodcast() -> MERGING_DATA_TYPE.PODCAST
+                        isSong -> MERGING_DATA_TYPE.SONG
+                        else -> MERGING_DATA_TYPE.VIDEO
+                    },
             ),
         customCacheKey = this.videoId,
     )

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
@@ -248,6 +248,10 @@ interface DataStoreManager {
 
     fun setPlaybackSpeed(speed: Float)
 
+    val podcastPlaybackSpeed: Flow<Float>
+
+    suspend fun setPodcastPlaybackSpeed(speed: Float)
+
     val podcastRewindSeconds: Flow<Int>
 
     suspend fun setPodcastRewindSeconds(seconds: Int)
@@ -259,6 +263,10 @@ interface DataStoreManager {
     val pitch: Flow<Int>
 
     fun setPitch(pitch: Int)
+
+    val podcastPitch: Flow<Int>
+
+    suspend fun setPodcastPitch(pitch: Int)
 
     val dataSyncId: Flow<String>
 

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
@@ -248,6 +248,14 @@ interface DataStoreManager {
 
     fun setPlaybackSpeed(speed: Float)
 
+    val podcastRewindSeconds: Flow<Int>
+
+    suspend fun setPodcastRewindSeconds(seconds: Int)
+
+    val podcastForwardSeconds: Flow<Int>
+
+    suspend fun setPodcastForwardSeconds(seconds: Int)
+
     val pitch: Flow<Int>
 
     fun setPitch(pitch: Int)
@@ -429,6 +437,12 @@ interface DataStoreManager {
         const val DEFAULT_THEME_COLOR_HEX = "FF8ECAE6"
 
         const val CROSSFADE_DURATION_AUTO = 0
+
+        const val DEFAULT_PODCAST_SEEK_SECONDS = 5
+        val PODCAST_SEEK_INTERVALS = listOf(5, 10, 15, 30, 60)
+
+        fun normalizePodcastSeekSeconds(seconds: Int): Int =
+            seconds.takeIf { it in PODCAST_SEEK_INTERVALS } ?: DEFAULT_PODCAST_SEEK_SECONDS
 
         const val PROXY_TYPE_HTTP = "http"
         const val PROXY_TYPE_SOCKS = "socks"

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/mediaservice/handler/MediaPlayerHandler.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/mediaservice/handler/MediaPlayerHandler.kt
@@ -173,6 +173,10 @@ sealed class PlayerEvent {
 
     data object Forward : PlayerEvent()
 
+    data class SeekBy(
+        val offsetMs: Long,
+    ) : PlayerEvent()
+
     data object Stop : PlayerEvent()
 
     data object Next : PlayerEvent()

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/mediaservice/handler/MediaPlayerHandler.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/mediaservice/handler/MediaPlayerHandler.kt
@@ -338,12 +338,15 @@ data class QueueData(
     fun isRadio(): Boolean = this.data.playlistType == PlaylistType.RADIO
 
     fun isPlaylist(): Boolean = this.data.playlistType == PlaylistType.PLAYLIST
+
+    fun isPodcast(): Boolean = this.data.playlistType == PlaylistType.PODCAST
 }
 
 enum class PlaylistType {
     PLAYLIST,
     LOCAL_PLAYLIST,
     RADIO,
+    PODCAST,
 }
 
 sealed class ToastType(

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/mediaservice/player/MediaPlayerListener.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/mediaservice/player/MediaPlayerListener.kt
@@ -16,6 +16,10 @@ interface MediaPlayerListener {
     // Default no-op so non-emitting implementors (e.g. the JVM adapter) don't have to override it.
     fun onSeeked(positionMs: Long) {}
 
+    // Android audio effects must be attached to the active player's real session, which is only
+    // available after ExoPlayer has prepared the stream.
+    fun onAudioSessionIdChanged(audioSessionId: Int) {}
+
     fun onMediaItemTransition(
         mediaItem: GenericMediaItem?,
         reason: Int,

--- a/domain/src/commonTest/kotlin/com/maxrave/domain/extension/PodcastMediaTypeTest.kt
+++ b/domain/src/commonTest/kotlin/com/maxrave/domain/extension/PodcastMediaTypeTest.kt
@@ -5,6 +5,7 @@ import com.maxrave.domain.data.model.browse.album.Track
 import com.maxrave.domain.data.model.searchResult.songs.Thumbnail
 import com.maxrave.domain.data.player.GenericMediaItem
 import com.maxrave.domain.data.player.GenericMediaMetadata
+import com.maxrave.domain.manager.DataStoreManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,6 +39,15 @@ class PodcastMediaTypeTest {
             )
 
         assertTrue(mediaItem.toSongEntity().isPodcast())
+    }
+
+    @Test
+    fun podcastSeekIntervalsRejectUnsupportedValues() {
+        assertEquals(30, DataStoreManager.normalizePodcastSeekSeconds(30))
+        assertEquals(
+            DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS,
+            DataStoreManager.normalizePodcastSeekSeconds(12),
+        )
     }
 
     private fun track(category: String) =

--- a/domain/src/commonTest/kotlin/com/maxrave/domain/extension/PodcastMediaTypeTest.kt
+++ b/domain/src/commonTest/kotlin/com/maxrave/domain/extension/PodcastMediaTypeTest.kt
@@ -1,0 +1,60 @@
+package com.maxrave.domain.extension
+
+import com.maxrave.common.MERGING_DATA_TYPE
+import com.maxrave.domain.data.model.browse.album.Track
+import com.maxrave.domain.data.model.searchResult.songs.Thumbnail
+import com.maxrave.domain.data.player.GenericMediaItem
+import com.maxrave.domain.data.player.GenericMediaMetadata
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PodcastMediaTypeTest {
+    @Test
+    fun podcastTrackKeepsItsTypeInPlayerMetadata() {
+        val track = track(category = MERGING_DATA_TYPE.PODCAST)
+
+        assertTrue(track.isPodcast())
+        assertTrue(track.toGenericMediaItem().isPodcast())
+        assertEquals(MERGING_DATA_TYPE.PODCAST, track.toGenericMediaItem().metadata.description)
+    }
+
+    @Test
+    fun regularTrackIsNotMarkedAsPodcast() {
+        val track = track(category = "Music")
+
+        assertFalse(track.isPodcast())
+        assertFalse(track.toGenericMediaItem().isPodcast())
+    }
+
+    @Test
+    fun podcastMetadataSurvivesConversionToDatabaseEntity() {
+        val mediaItem =
+            GenericMediaItem(
+                mediaId = "episode-id",
+                uri = "episode-id",
+                metadata = GenericMediaMetadata(description = MERGING_DATA_TYPE.PODCAST),
+            )
+
+        assertTrue(mediaItem.toSongEntity().isPodcast())
+    }
+
+    private fun track(category: String) =
+        Track(
+            album = null,
+            artists = emptyList(),
+            duration = "10:00",
+            durationSeconds = 600,
+            isAvailable = true,
+            isExplicit = false,
+            likeStatus = "INDIFFERENT",
+            thumbnails = listOf(Thumbnail(height = 100, url = "https://example.com/episode.jpg", width = 100)),
+            title = "Episode",
+            videoId = "episode-id",
+            videoType = category,
+            category = category,
+            feedbackTokens = null,
+            resultType = category,
+        )
+}

--- a/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayer.kt
+++ b/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayer.kt
@@ -555,6 +555,7 @@ class MpvPlayer private constructor(
     // own crossfade ramp. [applyVolume] decides how each reaches mpv.
     private var masterPercent = 100
     private var fadePercent = 100
+    private var speechBoostPercent = 100
 
     /**
      * The pipeline volume — what the volume slider controls. Must NOT be touched while a crossfade
@@ -579,6 +580,13 @@ class MpvPlayer private constructor(
         applyVolume()
     }
 
+    /** Adds modest software gain for spoken-word content without changing the user's volume setting. */
+    fun setSpeechBoost(enabled: Boolean) {
+        if (isReleased) return
+        speechBoostPercent = if (enabled) 125 else 100
+        applyVolume()
+    }
+
     /**
      * `volume` is mpv's *software* volume: applied inside the filter chain, so audio already queued
      * in the audio-output buffer keeps playing at the previous level — audible as a couple of
@@ -590,9 +598,9 @@ class MpvPlayer private constructor(
      */
     private fun applyVolume() {
         if (setPropertyDouble("ao-volume", masterPercent.toDouble(), logFailure = false) >= 0) {
-            setPropertyDouble("volume", fadePercent.toDouble())
+            setPropertyDouble("volume", fadePercent * speechBoostPercent / 100.0)
         } else {
-            setPropertyDouble("volume", masterPercent * fadePercent / 100.0)
+            setPropertyDouble("volume", masterPercent * fadePercent * speechBoostPercent / 10_000.0)
         }
     }
 

--- a/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayerAdapter.kt
+++ b/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayerAdapter.kt
@@ -5,6 +5,7 @@ import com.maxrave.domain.data.player.GenericMediaItem
 import com.maxrave.domain.data.player.GenericPlaybackParameters
 import com.maxrave.domain.data.player.PlayerConstants
 import com.maxrave.domain.data.player.PlayerError
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.extension.isVideo
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.mediaservice.player.MediaPlayerInterface
@@ -1063,6 +1064,7 @@ class MpvPlayerAdapter(
                     _currentVideoFrames.value = player.videoFrames
                     setupPlayerEventsInternal(player)
                     player.setMasterVolume((internalVolume * 100).toInt())
+                    player.setSpeechBoost(mediaItem.isPodcast())
 
                     if (cachedPrecache != null) {
                         // The precached handle already has the file loaded and held paused;
@@ -1097,7 +1099,11 @@ class MpvPlayerAdapter(
                     startPositionUpdates()
 
                     // Eagerly load audio metadata for auto crossfade / DJ mode calculations
-                    if (crossfadeEnabled && (crossfadeDurationMs == DataStoreManager.CROSSFADE_DURATION_AUTO || djCrossfadeEnabled)) {
+                    if (
+                        crossfadeEnabled &&
+                        !mediaItem.isPodcast() &&
+                        (crossfadeDurationMs == DataStoreManager.CROSSFADE_DURATION_AUTO || djCrossfadeEnabled)
+                    ) {
                         val currentVideoId = playlist.getOrNull(localCurrentMediaItemIndex)?.mediaId ?: ""
                         loadAudioMetaIfNeeded(currentVideoId)
                     }
@@ -1373,6 +1379,10 @@ class MpvPlayerAdapter(
     /** Same skip rule for the CURRENT track: a video should play out to its last frame instead of fading out under the incoming song. */
     private fun isCurrentTrackVideo(): Boolean = watchVideoEnabled && currentMediaItem?.isVideo() == true
 
+    private fun isNextTrackPodcast(): Boolean = playlist.getOrNull(getNextMediaItemIndex())?.isPodcast() == true
+
+    private fun isCurrentTrackPodcast(): Boolean = currentMediaItem?.isPodcast() == true
+
     /**
      * Handle track end
      */
@@ -1389,7 +1399,9 @@ class MpvPlayerAdapter(
             crossfadeEnabled &&
                 hasNextMediaItem() &&
                 !isCurrentTrackVideo() &&
-                !isNextTrackVideo()
+                !isNextTrackVideo() &&
+                !isCurrentTrackPodcast() &&
+                !isNextTrackPodcast()
 
         if (shouldCrossfade) {
             val nextIndex = getNextMediaItemIndex()
@@ -2255,7 +2267,9 @@ class MpvPlayerAdapter(
                                 !isCrossfading &&
                                 internalPlayWhenReady &&
                                 !isCurrentTrackVideo() &&
-                                !isNextTrackVideo()
+                                !isNextTrackVideo() &&
+                                !isCurrentTrackPodcast() &&
+                                !isNextTrackPodcast()
                             ) {
                                 val player = currentPlayer
                                 if (player != null) {

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -24,6 +24,7 @@ import com.maxrave.domain.data.player.GenericMediaItem
 import com.maxrave.domain.data.player.GenericPlaybackParameters
 import com.maxrave.domain.data.player.PlayerConstants
 import com.maxrave.domain.data.player.PlayerError
+import com.maxrave.domain.extension.isPodcast
 import com.maxrave.domain.extension.isVideo
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.mediaservice.player.MediaPlayerInterface
@@ -1426,7 +1427,11 @@ internal class CrossfadeExoPlayerAdapter(
 
                     // Eagerly load audio metadata for auto crossfade calculations
                     // so it's available when position updates check the trigger threshold
-                    if (crossfadeEnabled && crossfadeDurationMs == DataStoreManager.CROSSFADE_DURATION_AUTO) {
+                    if (
+                        crossfadeEnabled &&
+                        !mediaItem.isPodcast() &&
+                        crossfadeDurationMs == DataStoreManager.CROSSFADE_DURATION_AUTO
+                    ) {
                         loadAudioMetaIfNeeded(videoId)
                     }
 
@@ -1738,6 +1743,10 @@ internal class CrossfadeExoPlayerAdapter(
     /** Same skip rule for the CURRENT track: a video should play out to its last frame instead of fading out under the incoming song. */
     private fun isCurrentTrackVideo(): Boolean = watchVideoEnabled && currentMediaItem?.isVideo() == true
 
+    private fun isNextTrackPodcast(): Boolean = playlist.getOrNull(getNextMediaItemIndex())?.isPodcast() == true
+
+    private fun isCurrentTrackPodcast(): Boolean = currentMediaItem?.isPodcast() == true
+
     /**
      * Handle track end - mirrors GstreamerPlayerAdapter.handleTrackEndInternal()
      */
@@ -1750,7 +1759,9 @@ internal class CrossfadeExoPlayerAdapter(
                 hasNextMediaItem() &&
                 !isCrossfading &&
                 !isCurrentTrackVideo() &&
-                !isNextTrackVideo()
+                !isNextTrackVideo() &&
+                !isCurrentTrackPodcast() &&
+                !isNextTrackPodcast()
 
         if (shouldCrossfade) {
             val nextIndex = getNextMediaItemIndex()
@@ -2618,7 +2629,9 @@ internal class CrossfadeExoPlayerAdapter(
                                     dur > 0 &&
                                     pos > 0 &&
                                     !isCurrentTrackVideo() &&
-                                    !isNextTrackVideo()
+                                    !isNextTrackVideo() &&
+                                    !isCurrentTrackPodcast() &&
+                                    !isNextTrackPodcast()
                                 ) {
                                     // Account for playback speed: at higher speed, media time
                                     // is consumed faster, so wall-clock remaining is shorter

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -645,6 +645,7 @@ internal class CrossfadeExoPlayerAdapter(
         }
         currentPlayer?.let { player ->
             try {
+                forwardingPlayer.beginSeekBufferingSuppression()
                 player.seekTo(positionMs)
                 cachedPosition = positionMs
             } catch (e: Exception) {

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -1354,6 +1354,9 @@ internal class CrossfadeExoPlayerAdapter(
         currentLoadJob =
             coroutineScope.launch {
                 try {
+                    if (currentPlayer != null) {
+                        forwardingPlayer.beginTrackTransitionBufferingSuppression()
+                    }
                     transitionToState(InternalState.PREPARING)
 
                     // Notify media item transition

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -94,6 +94,12 @@ internal class CrossfadeExoPlayerAdapter(
 
     // ========== Crossfade Settings (loaded from DataStore) ==========
 
+    @Volatile
+    private var podcastRewindMs = DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS * 1_000L
+
+    @Volatile
+    private var podcastForwardMs = DataStoreManager.DEFAULT_PODCAST_SEEK_SECONDS * 1_000L
+
     init {
         coroutineScope.launch {
             dataStoreManager.crossfadeEnabled.collect { enabled ->
@@ -117,6 +123,16 @@ internal class CrossfadeExoPlayerAdapter(
             dataStoreManager.watchVideoInsteadOfPlayingAudio.collect { enabled ->
                 watchVideoEnabled = (enabled == DataStoreManager.TRUE)
                 Logger.d(TAG, "Watch video enabled: $watchVideoEnabled")
+            }
+        }
+        coroutineScope.launch {
+            dataStoreManager.podcastRewindSeconds.collect { seconds ->
+                podcastRewindMs = seconds * 1_000L
+            }
+        }
+        coroutineScope.launch {
+            dataStoreManager.podcastForwardSeconds.collect { seconds ->
+                podcastForwardMs = seconds * 1_000L
             }
         }
     }
@@ -373,6 +389,12 @@ internal class CrossfadeExoPlayerAdapter(
                 override fun seekToPrevious(): Unit = this@CrossfadeExoPlayerAdapter.seekToPrevious()
 
                 override fun seekToPreviousMediaItem(): Unit = this@CrossfadeExoPlayerAdapter.seekToPreviousMediaItem()
+            }
+        forwardingPlayer.seekIncrementProvider =
+            object : DelegatingForwardingPlayer.SeekIncrementProvider {
+                override fun getSeekBackIncrementMs(): Long = podcastRewindMs
+
+                override fun getSeekForwardIncrementMs(): Long = podcastForwardMs
             }
     }
 
@@ -663,13 +685,13 @@ internal class CrossfadeExoPlayerAdapter(
     }
 
     override fun seekBack() {
-        val newPosition = (currentPosition - 5000).coerceAtLeast(0)
+        val newPosition = (currentPosition - podcastRewindMs).coerceAtLeast(0)
         seekTo(newPosition)
     }
 
     override fun seekForward() {
         val end = duration.takeIf { it > 0 } ?: cachedDuration
-        val newPosition = (currentPosition + 5000).coerceAtMost(end)
+        val newPosition = (currentPosition + podcastForwardMs).coerceAtMost(end)
         seekTo(newPosition)
     }
 

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/CrossfadeExoPlayerAdapter.kt
@@ -128,6 +128,8 @@ internal class CrossfadeExoPlayerAdapter(
     @Volatile
     private var currentPlayer: ExoPlayer? = null
 
+    private var reportedAudioSessionId = C.AUDIO_SESSION_ID_UNSET
+
     @Volatile
     private var internalState = InternalState.IDLE
 
@@ -1371,9 +1373,11 @@ internal class CrossfadeExoPlayerAdapter(
                     // 3. Set new player as current
                     currentPlayer = player
                     currentPlayerFilter = playerFilter
+                    reportedAudioSessionId = C.AUDIO_SESSION_ID_UNSET
 
                     // 4. Setup our listener on new player
                     setupPlayerListenerInternal(player)
+                    reportActiveAudioSession(player)
 
                     // 5. Swap ForwardingPlayer delegate (moves MediaSession's listeners from old to new)
                     forwardingPlayer.swapDelegate(player)
@@ -1490,6 +1494,7 @@ internal class CrossfadeExoPlayerAdapter(
                             // Reset retry counter on successful playback
                             retryCount = 0
                             retryVideoId = null
+                            reportActiveAudioSession(player)
                         }
 
                         Player.STATE_BUFFERING -> {
@@ -1516,6 +1521,10 @@ internal class CrossfadeExoPlayerAdapter(
                             }
                         }
                     }
+                }
+
+                override fun onAudioSessionIdChanged(audioSessionId: Int) {
+                    reportActiveAudioSession(player, audioSessionId)
                 }
 
                 override fun onPlayerError(error: PlaybackException) {
@@ -1651,6 +1660,21 @@ internal class CrossfadeExoPlayerAdapter(
         activePlayerListener = listener
     }
 
+    private fun reportActiveAudioSession(
+        player: ExoPlayer,
+        audioSessionId: Int = player.audioSessionId,
+    ) {
+        if (
+            player != currentPlayer ||
+            audioSessionId == C.AUDIO_SESSION_ID_UNSET ||
+            audioSessionId == reportedAudioSessionId
+        ) {
+            return
+        }
+        reportedAudioSessionId = audioSessionId
+        listeners.forEach { it.onAudioSessionIdChanged(audioSessionId) }
+    }
+
     /**
      * Clean up active player listener from whichever player has it.
      * During crossfade the listener is on secondaryPlayer, not currentPlayer.
@@ -1714,8 +1738,10 @@ internal class CrossfadeExoPlayerAdapter(
         // Promote incoming (A+1) to current.
         currentPlayer = secondaryPlayer
         currentPlayerFilter = secondaryPlayerFilter
+        reportedAudioSessionId = C.AUDIO_SESSION_ID_UNSET
         secondaryPlayer = null
         secondaryPlayerFilter = null
+        currentPlayer?.let(::reportActiveAudioSession)
 
         // The incoming player was fading in: reduced volume + DJ filter on (and the
         // outgoing one carried any tempo/pitch match). Restore normal playback on A+1.
@@ -2562,8 +2588,10 @@ internal class CrossfadeExoPlayerAdapter(
         // Promote secondary to current
         currentPlayer = nextPlayer
         currentPlayerFilter = secondaryPlayerFilter
+        reportedAudioSessionId = C.AUDIO_SESSION_ID_UNSET
         secondaryPlayer = null
         secondaryPlayerFilter = null
+        currentPlayer?.let(::reportActiveAudioSession)
         // localCurrentMediaItemIndex already updated in triggerCrossfadeTransition()
 
         // Audio focus is held at the adapter level (see Audio Focus section),

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
@@ -1,5 +1,7 @@
 package com.maxrave.media3.exoplayer
 
+import android.os.Handler
+import android.os.Looper
 import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
@@ -11,6 +13,7 @@ import androidx.media3.common.util.UnstableApi
 import com.maxrave.logger.Logger
 
 private const val TAG = "DelegatingForwardingPlayer"
+private const val SEEK_BUFFERING_SUPPRESSION_TIMEOUT_MS = 2_000L
 
 /**
  * A [ForwardingPlayer] that allows runtime swapping of its underlying delegate.
@@ -101,6 +104,11 @@ internal class DelegatingForwardingPlayer(
         seekTo(if (duration > 0L) target.coerceAtMost(duration) else target)
     }
 
+    override fun seekTo(positionMs: Long) {
+        beginSeekBufferingSuppression()
+        super.seekTo(positionMs)
+    }
+
     // ========== Playback-Ended Suppression ==========
 
     /**
@@ -116,13 +124,42 @@ internal class DelegatingForwardingPlayer(
     @Volatile
     var suppressPlaybackEnded = false
 
+    @Volatile
+    private var suppressSeekBuffering = false
+
+    @Volatile
+    private var seekWasPlaying = false
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var seekSuppressionGeneration = 0
+
+    fun beginSeekBufferingSuppression() {
+        val generation = ++seekSuppressionGeneration
+        seekWasPlaying = isPlaying
+        suppressSeekBuffering = true
+        mainHandler.postDelayed(
+            {
+                if (seekSuppressionGeneration == generation) {
+                    suppressSeekBuffering = false
+                }
+            },
+            SEEK_BUFFERING_SUPPRESSION_TIMEOUT_MS,
+        )
+    }
+
     override fun getPlaybackState(): Int {
         val state = super.getPlaybackState()
         if (state == Player.STATE_ENDED && suppressPlaybackEnded) {
             return Player.STATE_BUFFERING
         }
+        if (state == Player.STATE_BUFFERING && suppressSeekBuffering) {
+            return Player.STATE_READY
+        }
         return state
     }
+
+    override fun isPlaying(): Boolean =
+        if (suppressSeekBuffering && seekWasPlaying) true else super.isPlaying()
 
     // ========== Listener Tracking ==========
 
@@ -137,6 +174,19 @@ internal class DelegatingForwardingPlayer(
     override fun removeListener(listener: Player.Listener) {
         trackedListeners.remove(listener)
         super.removeListener(listener)
+    }
+
+    private val seekBufferingListener =
+        object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (playbackState == Player.STATE_READY) {
+                    suppressSeekBuffering = false
+                }
+            }
+        }
+
+    init {
+        addListener(seekBufferingListener)
     }
 
     // ========== Video Surface Tracking ==========

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
@@ -78,6 +78,29 @@ internal class DelegatingForwardingPlayer(
      */
     var playlistNavigationProvider: PlaylistNavigationProvider? = null
 
+    interface SeekIncrementProvider {
+        fun getSeekBackIncrementMs(): Long
+
+        fun getSeekForwardIncrementMs(): Long
+    }
+
+    var seekIncrementProvider: SeekIncrementProvider? = null
+
+    override fun getSeekBackIncrement(): Long =
+        seekIncrementProvider?.getSeekBackIncrementMs() ?: super.getSeekBackIncrement()
+
+    override fun getSeekForwardIncrement(): Long =
+        seekIncrementProvider?.getSeekForwardIncrementMs() ?: super.getSeekForwardIncrement()
+
+    override fun seekBack() {
+        seekTo((currentPosition - seekBackIncrement).coerceAtLeast(0L))
+    }
+
+    override fun seekForward() {
+        val target = currentPosition + seekForwardIncrement
+        seekTo(if (duration > 0L) target.coerceAtMost(duration) else target)
+    }
+
     // ========== Playback-Ended Suppression ==========
 
     /**

--- a/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/exoplayer/DelegatingForwardingPlayer.kt
@@ -14,6 +14,7 @@ import com.maxrave.logger.Logger
 
 private const val TAG = "DelegatingForwardingPlayer"
 private const val SEEK_BUFFERING_SUPPRESSION_TIMEOUT_MS = 2_000L
+private const val TRACK_TRANSITION_BUFFERING_SUPPRESSION_TIMEOUT_MS = 15_000L
 
 /**
  * A [ForwardingPlayer] that allows runtime swapping of its underlying delegate.
@@ -130,6 +131,12 @@ internal class DelegatingForwardingPlayer(
     @Volatile
     private var seekWasPlaying = false
 
+    @Volatile
+    private var suppressTrackTransitionBuffering = false
+
+    @Volatile
+    private var trackTransitionWasPlaying = false
+
     private val mainHandler = Handler(Looper.getMainLooper())
     private var seekSuppressionGeneration = 0
 
@@ -147,19 +154,39 @@ internal class DelegatingForwardingPlayer(
         )
     }
 
+    fun beginTrackTransitionBufferingSuppression() {
+        val generation = ++seekSuppressionGeneration
+        trackTransitionWasPlaying = isPlaying || playWhenReady
+        suppressTrackTransitionBuffering = true
+        mainHandler.postDelayed(
+            {
+                if (seekSuppressionGeneration == generation) {
+                    suppressTrackTransitionBuffering = false
+                }
+            },
+            TRACK_TRANSITION_BUFFERING_SUPPRESSION_TIMEOUT_MS,
+        )
+    }
+
     override fun getPlaybackState(): Int {
         val state = super.getPlaybackState()
         if (state == Player.STATE_ENDED && suppressPlaybackEnded) {
             return Player.STATE_BUFFERING
         }
-        if (state == Player.STATE_BUFFERING && suppressSeekBuffering) {
+        if (state == Player.STATE_BUFFERING && (suppressSeekBuffering || suppressTrackTransitionBuffering)) {
             return Player.STATE_READY
         }
         return state
     }
 
     override fun isPlaying(): Boolean =
-        if (suppressSeekBuffering && seekWasPlaying) true else super.isPlaying()
+        if ((suppressSeekBuffering && seekWasPlaying) ||
+            (suppressTrackTransitionBuffering && trackTransitionWasPlaying)
+        ) {
+            true
+        } else {
+            super.isPlaying()
+        }
 
     // ========== Listener Tracking ==========
 
@@ -181,6 +208,7 @@ internal class DelegatingForwardingPlayer(
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (playbackState == Player.STATE_READY) {
                     suppressSeekBuffering = false
+                    suppressTrackTransitionBuffering = false
                 }
             }
         }

--- a/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
@@ -119,8 +119,6 @@ fun MediaItem.isSong(): Boolean = this.mediaMetadata.description?.contains(MERGI
 @UnstableApi
 fun MediaItem.isVideo(): Boolean = this.mediaMetadata.description?.contains(MERGING_DATA_TYPE.VIDEO) == true
 
-fun MediaItem.isPodcast(): Boolean = this.mediaMetadata.description?.contains(MERGING_DATA_TYPE.PODCAST) == true
-
 fun GenericCommandButton.toCommandButton(context: Context): CommandButton =
     when (this) {
         is GenericCommandButton.Like -> {

--- a/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.ContentMetadata
@@ -205,6 +206,40 @@ fun GenericCommandButton.toCommandButton(context: Context): CommandButton =
                     ),
                 ).build()
         }
+        is GenericCommandButton.SeekBack -> {
+            CommandButton
+                .Builder(skipBackIcon(this.seconds))
+                .setDisplayName(context.getString(R.string.seek_back_seconds, this.seconds))
+                .setPlayerCommand(Player.COMMAND_SEEK_BACK)
+                .setSlots(CommandButton.SLOT_BACK)
+                .build()
+        }
+        is GenericCommandButton.SeekForward -> {
+            CommandButton
+                .Builder(skipForwardIcon(this.seconds))
+                .setDisplayName(context.getString(R.string.seek_forward_seconds, this.seconds))
+                .setPlayerCommand(Player.COMMAND_SEEK_FORWARD)
+                .setSlots(CommandButton.SLOT_FORWARD)
+                .build()
+        }
+    }
+
+private fun skipBackIcon(seconds: Int): Int =
+    when (seconds) {
+        5 -> CommandButton.ICON_SKIP_BACK_5
+        10 -> CommandButton.ICON_SKIP_BACK_10
+        15 -> CommandButton.ICON_SKIP_BACK_15
+        30 -> CommandButton.ICON_SKIP_BACK_30
+        else -> CommandButton.ICON_SKIP_BACK
+    }
+
+private fun skipForwardIcon(seconds: Int): Int =
+    when (seconds) {
+        5 -> CommandButton.ICON_SKIP_FORWARD_5
+        10 -> CommandButton.ICON_SKIP_FORWARD_10
+        15 -> CommandButton.ICON_SKIP_FORWARD_15
+        30 -> CommandButton.ICON_SKIP_FORWARD_30
+        else -> CommandButton.ICON_SKIP_FORWARD
     }
 
 /**

--- a/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/extension/Media3Ext.kt
@@ -119,6 +119,8 @@ fun MediaItem.isSong(): Boolean = this.mediaMetadata.description?.contains(MERGI
 @UnstableApi
 fun MediaItem.isVideo(): Boolean = this.mediaMetadata.description?.contains(MERGING_DATA_TYPE.VIDEO) == true
 
+fun MediaItem.isPodcast(): Boolean = this.mediaMetadata.description?.contains(MERGING_DATA_TYPE.PODCAST) == true
+
 fun GenericCommandButton.toCommandButton(context: Context): CommandButton =
     when (this) {
         is GenericCommandButton.Like -> {

--- a/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
@@ -31,6 +31,7 @@ import com.maxrave.domain.mediaservice.handler.MediaPlayerHandler
 import com.maxrave.logger.Logger
 import com.maxrave.media3.R
 import com.maxrave.media3.extension.toCommandButton
+import com.maxrave.media3.extension.isPodcast
 import com.maxrave.media3.utils.CoilBitmapLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -63,7 +64,17 @@ internal class SimpleMediaService :
 
     private val binder = MusicBinder()
 
-    private lateinit var playerNotificationManager: PlayerNotificationManager
+    private var playerNotificationManager: PlayerNotificationManager? = null
+
+    private val keepAliveNotificationPlayerListener =
+        object : Player.Listener {
+            override fun onMediaItemTransition(
+                mediaItem: androidx.media3.common.MediaItem?,
+                reason: Int,
+            ) {
+                updateKeepAliveNotificationPlayer(mediaItem)
+            }
+        }
 
     inner class MusicBinder : Binder() {
         val service: SimpleMediaService
@@ -167,9 +178,10 @@ internal class SimpleMediaService :
                         },
                     ).setMediaDescriptionAdapter(DefaultMediaDescriptionAdapter(mediaSession?.sessionActivity))
                     .build()
-            playerNotificationManager.setPlayer(player)
-            playerNotificationManager.setSmallIcon(R.drawable.mono)
-            mediaSession?.platformToken?.let { playerNotificationManager.setMediaSessionToken(it) }
+            player.addListener(keepAliveNotificationPlayerListener)
+            updateKeepAliveNotificationPlayer(player.currentMediaItem)
+            playerNotificationManager?.setSmallIcon(R.drawable.mono)
+            mediaSession?.platformToken?.let { playerNotificationManager?.setMediaSessionToken(it) }
         }
 
         simpleMediaServiceHandler.onUpdateNotification = { list ->
@@ -203,6 +215,9 @@ internal class SimpleMediaService :
     @UnstableApi
     fun release() {
         Logger.w("Service", "Starting release process")
+        player.removeListener(keepAliveNotificationPlayerListener)
+        playerNotificationManager?.setPlayer(null)
+        playerNotificationManager = null
         runBlocking {
             try {
                 // Release MediaSession (don't release player - CrossfadeExoPlayerAdapter manages it)
@@ -266,5 +281,13 @@ internal class SimpleMediaService :
         val appProcessInfo = RunningAppProcessInfo()
         ActivityManager.getMyMemoryState(appProcessInfo)
         return appProcessInfo.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+    }
+
+    private fun updateKeepAliveNotificationPlayer(mediaItem: androidx.media3.common.MediaItem?) {
+        // PlayerNotificationManager predates Media3's session notification and publishes a
+        // second set of transport controls. On podcasts that duplicate notification can take
+        // over while paused, replacing the configured timed seek buttons with generic controls.
+        // Keep the legacy keep-alive behavior for music, but let the session own podcast media.
+        playerNotificationManager?.setPlayer(if (mediaItem?.isPodcast() == true) null else player)
     }
 }

--- a/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
+++ b/media/media3/src/main/java/com/maxrave/media3/service/SimpleMediaService.kt
@@ -3,9 +3,6 @@ package com.maxrave.media3.service
 import android.app.Activity
 import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo
-import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.ComponentName
 import android.content.Context
@@ -13,17 +10,18 @@ import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
 import android.os.Binder
 import android.os.Build
+import android.os.Bundle
 import android.os.IBinder
-import androidx.core.content.getSystemService
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaController
 import androidx.media3.session.MediaLibraryService
+import androidx.media3.session.MediaNotification
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionToken
-import androidx.media3.ui.DefaultMediaDescriptionAdapter
-import androidx.media3.ui.PlayerNotificationManager
+import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.MoreExecutors
 import com.maxrave.common.MEDIA_NOTIFICATION
 import com.maxrave.domain.manager.DataStoreManager
@@ -31,9 +29,9 @@ import com.maxrave.domain.mediaservice.handler.MediaPlayerHandler
 import com.maxrave.logger.Logger
 import com.maxrave.media3.R
 import com.maxrave.media3.extension.toCommandButton
-import com.maxrave.media3.extension.isPodcast
 import com.maxrave.media3.utils.CoilBitmapLoader
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
@@ -64,17 +62,9 @@ internal class SimpleMediaService :
 
     private val binder = MusicBinder()
 
-    private var playerNotificationManager: PlayerNotificationManager? = null
-
-    private val keepAliveNotificationPlayerListener =
-        object : Player.Listener {
-            override fun onMediaItemTransition(
-                mediaItem: androidx.media3.common.MediaItem?,
-                reason: Int,
-            ) {
-                updateKeepAliveNotificationPlayer(mediaItem)
-            }
-        }
+    @Volatile
+    private var keepAliveMediaNotification: MediaNotification? = null
+    private var keepAliveNotificationJob: Job? = null
 
     inner class MusicBinder : Binder() {
         val service: SimpleMediaService
@@ -105,7 +95,10 @@ internal class SimpleMediaService :
         super.onCreate()
         Logger.w("Service", "Simple Media Service Created")
 
-        setMediaNotificationProvider(
+        val keepServiceAlive = runBlocking {
+            dataStoreManager.keepServiceAlive.first() == DataStoreManager.TRUE
+        }
+        val defaultNotificationProvider =
             DefaultMediaNotificationProvider(
                 this,
                 { MEDIA_NOTIFICATION.NOTIFICATION_ID },
@@ -113,6 +106,36 @@ internal class SimpleMediaService :
                 R.string.notification_channel_name,
             ).apply {
                 setSmallIcon(R.drawable.mono)
+            }
+        setMediaNotificationProvider(
+            object : MediaNotification.Provider {
+                override fun createNotification(
+                    mediaSession: MediaSession,
+                    mediaButtonPreferences: ImmutableList<CommandButton>,
+                    actionFactory: MediaNotification.ActionFactory,
+                    onNotificationChangedCallback: MediaNotification.Provider.Callback,
+                ): MediaNotification =
+                    defaultNotificationProvider
+                        .createNotification(
+                            mediaSession,
+                            mediaButtonPreferences,
+                            actionFactory,
+                            onNotificationChangedCallback,
+                        ).also { notification ->
+                            if (keepServiceAlive) {
+                                keepAliveMediaNotification = notification
+                                startKeepAliveNotificationHeartbeat()
+                            }
+                        }
+
+                override fun handleCustomCommand(
+                    session: MediaSession,
+                    action: String,
+                    extras: Bundle,
+                ): Boolean = defaultNotificationProvider.handleCustomCommand(session, action, extras)
+
+                override fun getNotificationChannelInfo(): MediaNotification.Provider.NotificationChannelInfo =
+                    defaultNotificationProvider.notificationChannelInfo
             },
         )
 
@@ -135,54 +158,6 @@ internal class SimpleMediaService :
         val sessionToken = SessionToken(this, ComponentName(this, SimpleMediaService::class.java))
         val controllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
         controllerFuture.addListener({ controllerFuture.get() }, MoreExecutors.directExecutor())
-
-        if (runBlocking { dataStoreManager.keepServiceAlive.first() == DataStoreManager.TRUE }) {
-            val notificationManager = getSystemService<NotificationManager>()
-            notificationManager?.run {
-                createNotificationChannel(
-                    NotificationChannel(
-                        "media_playback_channel",
-                        "Now playing",
-                        NotificationManager.IMPORTANCE_LOW,
-                    ).apply {
-                        setSound(null, null)
-                        enableLights(false)
-                        enableVibration(false)
-                    },
-                )
-            }
-            playerNotificationManager =
-                PlayerNotificationManager
-                    .Builder(this, 2026, "media_playback_channel")
-                    .setNotificationListener(
-                        object : PlayerNotificationManager.NotificationListener {
-                            override fun onNotificationPosted(
-                                notificationId: Int,
-                                notification: Notification,
-                                ongoing: Boolean,
-                            ) {
-                                fun startFg() {
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                        startForeground(notificationId, notification, FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
-                                    } else {
-                                        startForeground(notificationId, notification)
-                                    }
-                                }
-                                coroutineScope.launch {
-                                    while (coroutineScope.isActive) {
-                                        startFg()
-                                        delay(30.seconds)
-                                    }
-                                }
-                            }
-                        },
-                    ).setMediaDescriptionAdapter(DefaultMediaDescriptionAdapter(mediaSession?.sessionActivity))
-                    .build()
-            player.addListener(keepAliveNotificationPlayerListener)
-            updateKeepAliveNotificationPlayer(player.currentMediaItem)
-            playerNotificationManager?.setSmallIcon(R.drawable.mono)
-            mediaSession?.platformToken?.let { playerNotificationManager?.setMediaSessionToken(it) }
-        }
 
         simpleMediaServiceHandler.onUpdateNotification = { list ->
             val commandButtonList = list.map { it.toCommandButton(this) }
@@ -215,9 +190,9 @@ internal class SimpleMediaService :
     @UnstableApi
     fun release() {
         Logger.w("Service", "Starting release process")
-        player.removeListener(keepAliveNotificationPlayerListener)
-        playerNotificationManager?.setPlayer(null)
-        playerNotificationManager = null
+        keepAliveNotificationJob?.cancel()
+        keepAliveNotificationJob = null
+        keepAliveMediaNotification = null
         runBlocking {
             try {
                 // Release MediaSession (don't release player - CrossfadeExoPlayerAdapter manages it)
@@ -283,11 +258,23 @@ internal class SimpleMediaService :
         return appProcessInfo.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 
-    private fun updateKeepAliveNotificationPlayer(mediaItem: androidx.media3.common.MediaItem?) {
-        // PlayerNotificationManager predates Media3's session notification and publishes a
-        // second set of transport controls. On podcasts that duplicate notification can take
-        // over while paused, replacing the configured timed seek buttons with generic controls.
-        // Keep the legacy keep-alive behavior for music, but let the session own podcast media.
-        playerNotificationManager?.setPlayer(if (mediaItem?.isPodcast() == true) null else player)
+    private fun startKeepAliveNotificationHeartbeat() {
+        if (keepAliveNotificationJob?.isActive == true) return
+        keepAliveNotificationJob =
+            coroutineScope.launch {
+                while (isActive) {
+                    val mediaNotification = keepAliveMediaNotification ?: break
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        startForeground(
+                            mediaNotification.notificationId,
+                            mediaNotification.notification,
+                            FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+                        )
+                    } else {
+                        startForeground(mediaNotification.notificationId, mediaNotification.notification)
+                    }
+                    delay(30.seconds)
+                }
+            }
     }
 }

--- a/media/media3/src/main/res/values/strings.xml
+++ b/media/media3/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="repeat_all">Repeat All</string>
     <string name="repeat_off">Repeat Off</string>
     <string name="shuffle">Shuffle</string>
+    <string name="seek_back_seconds">Back %1$d seconds</string>
+    <string name="seek_forward_seconds">Forward %1$d seconds</string>
     <string name="notification_channel_name" translatable="false">SimpMusic Playback Notification</string>
     <string name="home">Home</string>
     <string name="search">Search</string>


### PR DESCRIPTION
I've improved the podcast player and it makes it easier to control for longer episodes. I use this for my daily and this was just one of the things I felt was missing since I'm a big podcast listener

- Added forward and backward seek buttons for podcasts
- Added settings for 5, 10, 15, 30, or 60 second seek intervals on podcasts
- Added previous and next episode controls
- Podcasts now save playback progress
- Added download options for one episode or all episodes
- Added playback speed controls for podcasts that ignore crossfade settings since podcasts shouldn't crossfade
- Hid music only menu such as adding podcast episodes to playlists in the player menu
- Player and mini player show correct controls as well
- Android notifications, lock screen controls, and the One UI Now Bar now show podcast seek buttons instead of previous and next

Tested using android debug
- S24 Ultra (SM-S928U)
- Android 16
- SDK 36

Tested podcast playback, seeking, playback speed, episode progress, and switching between podcasts and music

Links to: https://github.com/maxrave-dev/SimpMusic/pull/2303
