### PR TITLE
feat(datastore): add ring player enabled setting

### DIFF
--- a/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/dataStore/DataStoreManagerImpl.kt
@@ -1312,6 +1312,19 @@ internal class DataStoreManagerImpl(
         }
     }
 
+    override val ringPlayerEnabled: Flow<String> =
+        settingsDataStore.data.map { preferences ->
+            preferences[RING_PLAYER_ENABLED] ?: FALSE
+        }
+
+    override suspend fun setRingPlayerEnabled(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            settingsDataStore.edit { settings ->
+                settings[RING_PLAYER_ENABLED] = if (enabled) TRUE else FALSE
+            }
+        }
+    }
+
     override val explicitContentEnabled: Flow<String> =
         settingsDataStore.data.map { preferences ->
             preferences[EXPLICIT_CONTENT_ENABLED] ?: TRUE
@@ -1566,6 +1579,8 @@ internal class DataStoreManagerImpl(
         val BACKUP_DOWNLOADED = stringPreferencesKey("backup_downloaded")
 
         val LIQUID_GLASS = stringPreferencesKey("liquid_glass")
+
+        val RING_PLAYER_ENABLED = stringPreferencesKey("ring_player_enabled")
 
         val EXPLICIT_CONTENT_ENABLED = stringPreferencesKey("explicit_content_enabled")
 

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/manager/DataStoreManager.kt
@@ -329,6 +329,11 @@ interface DataStoreManager {
 
     suspend fun setEnableLiquidGlass(enable: Boolean)
 
+    /** Whether the player should use the ring/vinyl UI instead of the normal layout. */
+    val ringPlayerEnabled: Flow<String>
+
+    suspend fun setRingPlayerEnabled(enabled: Boolean)
+
     /** One of [THEME_MODE_SYSTEM], [THEME_MODE_DARK], [THEME_MODE_LIGHT]. */
     val themeMode: Flow<String>
 


### PR DESCRIPTION
Adds the DataStore plumbing for the new Ring player option (spinning vinyl + progress ring in the player bars).

- New \ingPlayerEnabled: Flow<String>\ + \setRingPlayerEnabled(enabled: Boolean)\ in \DataStoreManager\
- Impl in \DataStoreManagerImpl\ using the \ing_player_enabled\ preference key

Consumed by https://github.com/maxrave-dev/SimpMusic/pull/2310 (ring player UI).