### PR TITLE
Add Spotify playlist browsing + YouTube Music track matching

### DIFF
--- a/common/src/commonMain/kotlin/com/maxrave/common/Config.kt
+++ b/common/src/commonMain/kotlin/com/maxrave/common/Config.kt
@@ -562,6 +562,7 @@ enum class LibraryChipType {
     FAVORITE_PLAYLIST,
     DOWNLOADED_PLAYLIST,
     FAVORITE_PODCAST,
+    SPOTIFY_PLAYLIST,
     ;
 
     fun toStringValue(): String =
@@ -574,6 +575,7 @@ enum class LibraryChipType {
             DOWNLOADED_PLAYLIST -> "downloaded_playlist"
             FAVORITE_PODCAST -> "favorite_podcast"
             CHART -> "chart"
+            SPOTIFY_PLAYLIST -> "spotify_playlist"
         }
 
     companion object {
@@ -587,6 +589,7 @@ enum class LibraryChipType {
                 "downloaded_playlist" -> DOWNLOADED_PLAYLIST
                 "favorite_podcast" -> FAVORITE_PODCAST
                 "chart" -> CHART
+                "spotify_playlist" -> SPOTIFY_PLAYLIST
                 else -> null
             }
     }

--- a/data/src/commonMain/kotlin/com/maxrave/data/di/DatabaseModule.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.maxrave.data.dataStore.DataStoreManagerImpl
 import com.maxrave.data.dataStore.createDataStoreInstance
 import com.maxrave.data.db.Converters
+import com.maxrave.data.spotify.SpotifyTokenProvider
 import com.maxrave.data.db.MusicDatabase
 import com.maxrave.data.db.datasource.AnalyticsDatasource
 import com.maxrave.data.db.datasource.LocalDataSource
@@ -64,6 +65,10 @@ val databaseModule =
 
         single(createdAtStart = true) {
             Spotify()
+        }
+
+        single(createdAtStart = true) {
+            SpotifyTokenProvider(get<Spotify>())
         }
 
         single(createdAtStart = true) {

--- a/data/src/commonMain/kotlin/com/maxrave/data/di/RepositoryModule.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/di/RepositoryModule.kt
@@ -15,6 +15,7 @@ import com.maxrave.data.repository.PlaylistRepositoryImpl
 import com.maxrave.data.repository.PodcastRepositoryImpl
 import com.maxrave.data.repository.SearchRepositoryImpl
 import com.maxrave.data.repository.SongRepositoryImpl
+import com.maxrave.data.repository.SpotifyLibraryRepositoryImpl
 import com.maxrave.data.repository.StreamRepositoryImpl
 import com.maxrave.data.repository.UpdateRepositoryImpl
 import com.maxrave.domain.repository.AccountRepository
@@ -30,6 +31,7 @@ import com.maxrave.domain.repository.PlaylistRepository
 import com.maxrave.domain.repository.PodcastRepository
 import com.maxrave.domain.repository.SearchRepository
 import com.maxrave.domain.repository.SongRepository
+import com.maxrave.domain.repository.SpotifyLibraryRepository
 import com.maxrave.domain.repository.StreamRepository
 import com.maxrave.domain.repository.UpdateRepository
 import org.koin.core.qualifier.named
@@ -68,7 +70,7 @@ val repositoryModule =
         }
 
         single<LyricsCanvasRepository>(createdAtStart = true) {
-            LyricsCanvasRepositoryImpl(get(), get(), get(), get(), get())
+            LyricsCanvasRepositoryImpl(get(), get(), get(), get(), get(), get())
         }
 
         single<PlaylistRepository>(createdAtStart = true) {
@@ -85,6 +87,10 @@ val repositoryModule =
 
         single<SongRepository>(createdAtStart = true) {
             SongRepositoryImpl(get(), get(), get())
+        }
+
+        single<SpotifyLibraryRepository>(createdAtStart = true) {
+            SpotifyLibraryRepositoryImpl(get(), get(), get(), get())
         }
 
         single<StreamRepository>(createdAtStart = true) {

--- a/data/src/commonMain/kotlin/com/maxrave/data/mapping/SpotifyMapping.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/mapping/SpotifyMapping.kt
@@ -1,0 +1,54 @@
+package com.maxrave.data.mapping
+
+import com.maxrave.domain.data.model.spotify.SpotifyPlaylist
+import com.maxrave.domain.data.model.spotify.SpotifyTrack
+import com.maxrave.spotify.model.response.spotify.playlist.SpotifyLibraryPlaylistsResponse
+import com.maxrave.spotify.model.response.spotify.playlist.SpotifyPlaylistTracksResponse
+
+internal fun SpotifyLibraryPlaylistsResponse.toSpotifyPlaylists(): List<SpotifyPlaylist> =
+    data
+        ?.me
+        ?.libraryV3
+        ?.items
+        ?.mapNotNull { it.item?.data }
+        ?.mapNotNull { playlist ->
+            val id = playlist.id ?: return@mapNotNull null
+            SpotifyPlaylist(
+                id = id,
+                name = playlist.name.orEmpty(),
+                description = playlist.description,
+                imageUrl =
+                    playlist.images
+                        ?.items
+                        ?.firstOrNull()
+                        ?.sources
+                        ?.maxByOrNull { it.width ?: 0 }
+                        ?.url,
+                ownerName = playlist.ownerV2?.data?.name,
+                trackCount = playlist.content?.totalCount,
+            )
+        }.orEmpty()
+
+internal fun SpotifyPlaylistTracksResponse.toSpotifyTracks(): List<SpotifyTrack> =
+    data
+        ?.playlistV2
+        ?.content
+        ?.items
+        ?.mapNotNull { it.itemV2?.data }
+        ?.mapNotNull { track ->
+            val id = track.spotifyId ?: return@mapNotNull null
+            SpotifyTrack(
+                id = id,
+                title = track.name.orEmpty(),
+                artists = track.artistNames,
+                albumName = track.albumOfTrack?.name,
+                albumImageUrl =
+                    track.albumOfTrack
+                        ?.coverArt
+                        ?.sources
+                        ?.maxByOrNull { it.width ?: 0 }
+                        ?.url,
+                durationMs = track.durationMs,
+                isExplicit = track.isExplicit,
+            )
+        }.orEmpty()

--- a/data/src/commonMain/kotlin/com/maxrave/data/repository/LyricsCanvasRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/repository/LyricsCanvasRepositoryImpl.kt
@@ -5,6 +5,7 @@ package com.maxrave.data.repository
 import com.maxrave.data.db.datasource.LocalDataSource
 import com.maxrave.data.mapping.toCanvasResult
 import com.maxrave.data.mapping.toLyrics
+import com.maxrave.data.spotify.SpotifyTokenProvider
 import com.maxrave.domain.data.entities.LyricsEntity
 import com.maxrave.domain.data.entities.TranslatedLyricsEntity
 import com.maxrave.domain.data.model.browse.album.Track
@@ -12,7 +13,6 @@ import com.maxrave.domain.data.model.browse.artist.ArtistLogo
 import com.maxrave.domain.data.model.canvas.CanvasResult
 import com.maxrave.domain.data.model.metadata.Lyrics
 import com.maxrave.domain.data.model.metadata.SimpMusicLyrics
-import com.maxrave.domain.extension.now
 import com.maxrave.domain.manager.DataStoreManager
 import com.maxrave.domain.repository.LyricsCanvasRepository
 import com.maxrave.domain.utils.Resource
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.simpmusic.aiservice.AiClient
 import org.simpmusic.lyrics.SimpMusicLyricsClient
@@ -40,7 +39,6 @@ import org.simpmusic.lyrics.models.request.LyricsBody
 import org.simpmusic.lyrics.models.request.TranslatedLyricsBody
 import org.simpmusic.lyrics.parser.parseTtmlLyrics
 import kotlin.math.abs
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 internal class LyricsCanvasRepositoryImpl(
@@ -49,6 +47,7 @@ internal class LyricsCanvasRepositoryImpl(
     private val spotify: Spotify,
     private val simpMusicLyrics: SimpMusicLyricsClient,
     private val aiClient: AiClient,
+    private val spotifyTokenProvider: SpotifyTokenProvider,
 ) : LyricsCanvasRepository {
     override fun getSavedLyrics(videoId: String): Flow<LyricsEntity?> = flow { emit(localDataSource.getSavedLyrics(videoId)) }.flowOn(Dispatchers.IO)
 
@@ -115,52 +114,9 @@ internal class LyricsCanvasRepositoryImpl(
                             .replace(Regex("([()])"), "")
                             .replace(".", " ")
                             .replace("  ", " ")
-                    var spotifyPersonalToken = ""
-                    var spotifyClientToken = ""
-                    Logger.w("Lyrics", "getSpotifyLyrics: ${dataStoreManager.spotifyPersonalTokenExpires.first()}")
-                    Logger.w("Lyrics", "getSpotifyLyrics ${dataStoreManager.spotifyClientTokenExpires.first()}")
-                    Logger.w("Lyrics", "getSpotifyLyrics now: ${now()}")
-                    if (dataStoreManager.spotifyPersonalToken
-                            .first()
-                            .isNotEmpty() &&
-                        dataStoreManager.spotifyClientToken.first().isNotEmpty() &&
-                        dataStoreManager.spotifyPersonalTokenExpires.first() > Clock.System.now().toEpochMilliseconds() &&
-                        dataStoreManager.spotifyPersonalTokenExpires.first() != 0L &&
-                        dataStoreManager.spotifyClientTokenExpires.first() > Clock.System.now().toEpochMilliseconds() &&
-                        dataStoreManager.spotifyClientTokenExpires.first() != 0L
-                    ) {
-                        spotifyPersonalToken = dataStoreManager.spotifyPersonalToken.first()
-                        spotifyClientToken = dataStoreManager.spotifyClientToken.first()
-                        Logger.d("Canvas", "spotifyPersonalToken: $spotifyPersonalToken")
-                        Logger.d("Canvas", "spotifyClientToken: $spotifyClientToken")
-                    } else if (dataStoreManager.spdc.first().isNotEmpty()) {
-                        spotify
-                            .getClientToken()
-                            .onSuccess {
-                                Logger.d("Canvas", "Request clientToken: ${it.grantedToken.token}")
-                                dataStoreManager.setSpotifyClientTokenExpires(
-                                    (it.grantedToken.expiresAfterSeconds * 1000L) + Clock.System.now().toEpochMilliseconds(),
-                                )
-                                dataStoreManager.setSpotifyClientToken(it.grantedToken.token)
-                                spotifyClientToken = it.grantedToken.token
-                            }.onFailure {
-                                it.printStackTrace()
-                                emit(Resource.Error<CanvasResult>(it.message ?: "Not found"))
-                            }
-                        spotify
-                            .getPersonalTokenWithTotp(dataStoreManager.spdc.first())
-                            .onSuccess {
-                                spotifyPersonalToken = it.accessToken
-                                dataStoreManager.setSpotifyPersonalToken(spotifyPersonalToken)
-                                dataStoreManager.setSpotifyPersonalTokenExpires(
-                                    it.accessTokenExpirationTimestampMs,
-                                )
-                                Logger.d("Canvas", "Request spotifyPersonalToken: $spotifyPersonalToken")
-                            }.onFailure {
-                                it.printStackTrace()
-                                emit(Resource.Error<CanvasResult>(it.message ?: "Not found"))
-                            }
-                    }
+                    val tokens = spotifyTokenProvider.getValidTokens(dataStoreManager)
+                    val spotifyPersonalToken = tokens?.personalToken ?: ""
+                    val spotifyClientToken = tokens?.clientToken ?: ""
                     if (spotifyPersonalToken.isNotEmpty() && spotifyClientToken.isNotEmpty()) {
                         val authToken = spotifyPersonalToken
                         spotify
@@ -262,52 +218,11 @@ internal class LyricsCanvasRepositoryImpl(
                         .replace(".", " ")
                         .replace("  ", " ")
                 Logger.d("Lyrics", "query: $q")
-                var spotifyPersonalToken = ""
-                var spotifyClientToken = ""
-                Logger.w("Lyrics", "getSpotifyLyrics: ${dataStoreManager.spotifyPersonalTokenExpires.first()}")
-                if (dataStoreManager.spotifyPersonalToken
-                        .first()
-                        .isNotEmpty() &&
-                    dataStoreManager.spotifyPersonalTokenExpires.first() > Clock.System.now().toEpochMilliseconds() &&
-                    dataStoreManager.spotifyPersonalTokenExpires.first() != 0L &&
-                    dataStoreManager.spotifyClientTokenExpires.first() > Clock.System.now().toEpochMilliseconds() &&
-                    dataStoreManager.spotifyClientTokenExpires.first() != 0L
-                ) {
-                    spotifyPersonalToken = dataStoreManager.spotifyPersonalToken.first()
-                    spotifyClientToken = dataStoreManager.spotifyClientToken.first()
-                    Logger.d("Lyrics", "spotifyPersonalToken: $spotifyPersonalToken")
-                    Logger.d("Lyrics", "spotifyClientToken: $spotifyClientToken")
-                } else if (dataStoreManager.spdc.first().isNotEmpty()) {
-                    runBlocking {
-                        spotify
-                            .getClientToken()
-                            .onSuccess {
-                                Logger.d("Canvas", "Request clientToken: ${it.grantedToken.token}")
-                                dataStoreManager.setSpotifyClientTokenExpires(
-                                    (it.grantedToken.expiresAfterSeconds * 1000L) + Clock.System.now().toEpochMilliseconds(),
-                                )
-                                dataStoreManager.setSpotifyClientToken(it.grantedToken.token)
-                                spotifyClientToken = it.grantedToken.token
-                            }.onFailure {
-                                it.printStackTrace()
-                                emit(Resource.Error<Lyrics>("Not found"))
-                            }
-                    }
-                    runBlocking {
-                        spotify
-                            .getPersonalTokenWithTotp(dataStoreManager.spdc.first())
-                            .onSuccess {
-                                spotifyPersonalToken = it.accessToken
-                                dataStoreManager.setSpotifyPersonalToken(spotifyPersonalToken)
-                                dataStoreManager.setSpotifyPersonalTokenExpires(
-                                    it.accessTokenExpirationTimestampMs,
-                                )
-                                Logger.d("Lyrics", "REQUEST spotifyPersonalToken: $spotifyPersonalToken")
-                            }.onFailure {
-                                it.printStackTrace()
-                                emit(Resource.Error<Lyrics>("Not found"))
-                            }
-                    }
+                val tokens = spotifyTokenProvider.getValidTokens(dataStoreManager)
+                val spotifyPersonalToken = tokens?.personalToken ?: ""
+                val spotifyClientToken = tokens?.clientToken ?: ""
+                if (spotifyPersonalToken.isEmpty() || spotifyClientToken.isEmpty()) {
+                    emit(Resource.Error<Lyrics>("Not found"))
                 }
                 if (spotifyPersonalToken.isNotEmpty() && spotifyClientToken.isNotEmpty()) {
                     val authToken = spotifyPersonalToken

--- a/data/src/commonMain/kotlin/com/maxrave/data/repository/SpotifyLibraryRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/repository/SpotifyLibraryRepositoryImpl.kt
@@ -1,0 +1,84 @@
+package com.maxrave.data.repository
+
+import com.maxrave.data.mapping.toSpotifyPlaylists
+import com.maxrave.data.mapping.toSpotifyTracks
+import com.maxrave.data.spotify.SpotifyTokenProvider
+import com.maxrave.domain.data.model.browse.album.Track
+import com.maxrave.domain.data.model.spotify.SpotifyPlaylist
+import com.maxrave.domain.data.model.spotify.SpotifyTrack
+import com.maxrave.domain.manager.DataStoreManager
+import com.maxrave.domain.repository.SearchRepository
+import com.maxrave.domain.repository.SpotifyLibraryRepository
+import com.maxrave.domain.utils.LocalResource
+import com.maxrave.domain.utils.Resource
+import com.maxrave.domain.utils.buildYoutubeSearchQuery
+import com.maxrave.domain.utils.rankSongMatches
+import com.maxrave.domain.utils.toTrack
+import com.maxrave.domain.utils.wrapResultResource
+import com.maxrave.logger.Logger
+import com.maxrave.spotify.Spotify
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+internal class SpotifyLibraryRepositoryImpl(
+    private val spotify: Spotify,
+    private val spotifyTokenProvider: SpotifyTokenProvider,
+    private val dataStoreManager: DataStoreManager,
+    private val searchRepository: SearchRepository,
+) : SpotifyLibraryRepository {
+    // In-memory only - Spotify tracks aren't persisted, so a resolved match only needs to
+    // survive for the current session (re-opening the playlist next launch just re-resolves).
+    private val resolvedTrackCache = mutableMapOf<String, Track?>()
+
+    override fun isLoggedIn(): Flow<Boolean> = dataStoreManager.spdc.map { it.isNotEmpty() }
+
+    override fun getUserPlaylists(
+        offset: Int,
+        limit: Int,
+    ): Flow<LocalResource<List<SpotifyPlaylist>>> =
+        wrapResultResource {
+            val tokens =
+                spotifyTokenProvider.getValidTokens(dataStoreManager)
+                    ?: return@wrapResultResource Result.failure(Exception("Not logged in to Spotify"))
+            spotify
+                .getUserPlaylists(tokens.personalToken, tokens.clientToken, offset, limit)
+                .map { it.toSpotifyPlaylists() }
+        }
+
+    override fun getPlaylistTracks(
+        playlistId: String,
+        offset: Int,
+        limit: Int,
+    ): Flow<LocalResource<List<SpotifyTrack>>> =
+        wrapResultResource {
+            val tokens =
+                spotifyTokenProvider.getValidTokens(dataStoreManager)
+                    ?: return@wrapResultResource Result.failure(Exception("Not logged in to Spotify"))
+            spotify
+                .getPlaylistTracks(playlistId, tokens.personalToken, tokens.clientToken, offset, limit)
+                .map { it.toSpotifyTracks() }
+        }
+
+    override suspend fun resolveTrack(track: SpotifyTrack): Track? {
+        resolvedTrackCache[track.id]?.let { return it }
+        if (resolvedTrackCache.containsKey(track.id)) {
+            // Cached negative result (no match found last time).
+            return null
+        }
+
+        val query = buildYoutubeSearchQuery(track.title, track.artists.firstOrNull())
+        val candidates =
+            when (val resource = searchRepository.getSearchDataSong(query).first()) {
+                is Resource.Success -> resource.data
+                is Resource.Error -> null
+            }.orEmpty()
+        val bestMatch = rankSongMatches(track, candidates)
+        if (bestMatch == null) {
+            Logger.w("SpotifyLibraryRepository", "No YouTube Music match for Spotify track: ${track.title}")
+        }
+        val resolved = bestMatch?.toTrack()
+        resolvedTrackCache[track.id] = resolved
+        return resolved
+    }
+}

--- a/data/src/commonMain/kotlin/com/maxrave/data/spotify/SpotifyTokenProvider.kt
+++ b/data/src/commonMain/kotlin/com/maxrave/data/spotify/SpotifyTokenProvider.kt
@@ -1,0 +1,87 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.maxrave.data.spotify
+
+import com.maxrave.domain.manager.DataStoreManager
+import com.maxrave.logger.Logger
+import com.maxrave.spotify.Spotify
+import kotlinx.coroutines.flow.first
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * A ready-to-use Spotify (personalToken, clientToken) pair.
+ */
+data class SpotifyTokens(
+    val personalToken: String,
+    val clientToken: String,
+)
+
+/**
+ * Returns a valid `(personalToken, clientToken)` pair for calling Spotify's internal
+ * pathfinder/GraphQL API, using the already-cached tokens in [DataStoreManager] if they
+ * haven't expired yet, or minting fresh ones (via the `sp_dc` cookie + TOTP flow already
+ * implemented in [Spotify]) otherwise. Returns `null` if the user isn't logged in to
+ * Spotify (no `sp_dc` cookie saved) or refresh fails.
+ *
+ * This is the same expiry-check-and-refresh logic that used to be duplicated inline in
+ * [com.maxrave.data.repository.LyricsCanvasRepositoryImpl] (Canvas + lyrics), factored out
+ * so it can also back Spotify playlist/library fetching.
+ */
+class SpotifyTokenProvider(
+    private val spotify: Spotify,
+) {
+    suspend fun getValidTokens(dataStoreManager: DataStoreManager): SpotifyTokens? {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val cachedPersonalToken = dataStoreManager.spotifyPersonalToken.first()
+        val cachedClientToken = dataStoreManager.spotifyClientToken.first()
+        val personalTokenExpires = dataStoreManager.spotifyPersonalTokenExpires.first()
+        val clientTokenExpires = dataStoreManager.spotifyClientTokenExpires.first()
+
+        if (cachedPersonalToken.isNotEmpty() &&
+            cachedClientToken.isNotEmpty() &&
+            personalTokenExpires != 0L &&
+            personalTokenExpires > now &&
+            clientTokenExpires != 0L &&
+            clientTokenExpires > now
+        ) {
+            return SpotifyTokens(cachedPersonalToken, cachedClientToken)
+        }
+
+        val spdc = dataStoreManager.spdc.first()
+        if (spdc.isEmpty()) {
+            // Not logged in to Spotify.
+            return null
+        }
+
+        var clientToken = ""
+        spotify
+            .getClientToken()
+            .onSuccess {
+                clientToken = it.grantedToken.token
+                dataStoreManager.setSpotifyClientToken(clientToken)
+                dataStoreManager.setSpotifyClientTokenExpires(
+                    (it.grantedToken.expiresAfterSeconds * 1000L) + Clock.System.now().toEpochMilliseconds(),
+                )
+            }.onFailure {
+                Logger.e("SpotifyTokenProvider", "Failed to get client token: ${it.message}")
+            }
+
+        var personalToken = ""
+        spotify
+            .getPersonalTokenWithTotp(spdc)
+            .onSuccess {
+                personalToken = it.accessToken
+                dataStoreManager.setSpotifyPersonalToken(personalToken)
+                dataStoreManager.setSpotifyPersonalTokenExpires(it.accessTokenExpirationTimestampMs)
+            }.onFailure {
+                Logger.e("SpotifyTokenProvider", "Failed to get personal token: ${it.message}")
+            }
+
+        return if (personalToken.isNotEmpty() && clientToken.isNotEmpty()) {
+            SpotifyTokens(personalToken, clientToken)
+        } else {
+            null
+        }
+    }
+}

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/data/model/spotify/SpotifyPlaylist.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/data/model/spotify/SpotifyPlaylist.kt
@@ -1,0 +1,16 @@
+package com.maxrave.domain.data.model.spotify
+
+/**
+ * A playlist fetched live from Spotify's own library (not a SimpMusic [com.maxrave.domain.data.entities.LocalPlaylistEntity]).
+ * Its tracks are Spotify metadata only - they aren't playable until resolved to a
+ * matching YouTube Music [com.maxrave.domain.data.model.browse.album.Track] via
+ * [com.maxrave.domain.repository.SpotifyLibraryRepository.resolveTrack].
+ */
+data class SpotifyPlaylist(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val imageUrl: String?,
+    val ownerName: String?,
+    val trackCount: Int?,
+)

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/data/model/spotify/SpotifyTrack.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/data/model/spotify/SpotifyTrack.kt
@@ -1,0 +1,16 @@
+package com.maxrave.domain.data.model.spotify
+
+/**
+ * A track as reported by Spotify's own metadata - title/artist/album/duration only.
+ * Not directly playable: SimpMusic streams from YouTube, so this must first be
+ * resolved to a matching YouTube Music track (see [com.maxrave.domain.repository.SpotifyLibraryRepository]).
+ */
+data class SpotifyTrack(
+    val id: String,
+    val title: String,
+    val artists: List<String>,
+    val albumName: String?,
+    val albumImageUrl: String?,
+    val durationMs: Long?,
+    val isExplicit: Boolean,
+)

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/repository/SpotifyLibraryRepository.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/repository/SpotifyLibraryRepository.kt
@@ -1,0 +1,41 @@
+package com.maxrave.domain.repository
+
+import com.maxrave.domain.data.model.browse.album.Track
+import com.maxrave.domain.data.model.spotify.SpotifyPlaylist
+import com.maxrave.domain.data.model.spotify.SpotifyTrack
+import com.maxrave.domain.utils.LocalResource
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Live-browsing access to the logged-in user's Spotify playlists (see [com.maxrave.spotify.Spotify]
+ * for the underlying `sp_dc`-cookie + TOTP auth, already implemented for Canvas/lyrics).
+ *
+ * Playlists/tracks here are fetched fresh from Spotify each time - they are intentionally
+ * *not* persisted as [com.maxrave.domain.data.entities.LocalPlaylistEntity] rows, mirroring how
+ * the existing YouTube Music library chip already works.
+ */
+interface SpotifyLibraryRepository {
+    /**
+     * Whether the user has a saved Spotify session (`sp_dc` cookie), i.e. can browse playlists.
+     */
+    fun isLoggedIn(): Flow<Boolean>
+
+    fun getUserPlaylists(offset: Int = 0, limit: Int = 50): Flow<LocalResource<List<SpotifyPlaylist>>>
+
+    fun getPlaylistTracks(
+        playlistId: String,
+        offset: Int = 0,
+        limit: Int = 100,
+    ): Flow<LocalResource<List<SpotifyTrack>>>
+
+    /**
+     * Resolve a Spotify track to the best-matching YouTube Music [Track], by searching
+     * SimpMusic's own YouTube Music search for "<title> <first artist>" and ranking the
+     * results (see `SpotifyTrackMatcher.rankSongMatches`). Returns `null` if no candidate
+     * was found - callers should show the track as unavailable rather than fail the whole
+     * playlist load.
+     *
+     * Resolution is cached in-memory per Spotify track id for the lifetime of the process.
+     */
+    suspend fun resolveTrack(track: SpotifyTrack): Track?
+}

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/utils/SpotifySearchQuery.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/utils/SpotifySearchQuery.kt
@@ -1,0 +1,20 @@
+package com.maxrave.domain.utils
+
+/**
+ * Builds a YouTube Music search query out of a track title + first artist, stripping the
+ * same feature/joiner noise (`feat.`, `ft.`, `&`, `và`, `và`, etc.) that
+ * `LyricsCanvasRepositoryImpl.getCanvas` already strips before searching Spotify for Canvas -
+ * same idea, just aimed at YouTube Music instead.
+ */
+fun buildYoutubeSearchQuery(
+    title: String,
+    firstArtist: String?,
+): String =
+    "$title ${firstArtist.orEmpty()}"
+        .replace(Regex("\\((feat\\.|ft.|cùng với|con|mukana|com|avec|合作音乐人: ) "), " ")
+        .replace(Regex("( và | & | и | e | und |, |和| dan)"), " ")
+        .replace("  ", " ")
+        .replace(Regex("([()])"), "")
+        .replace(".", " ")
+        .replace("  ", " ")
+        .trim()

--- a/domain/src/commonMain/kotlin/com/maxrave/domain/utils/SpotifyTrackMatcher.kt
+++ b/domain/src/commonMain/kotlin/com/maxrave/domain/utils/SpotifyTrackMatcher.kt
@@ -1,0 +1,63 @@
+package com.maxrave.domain.utils
+
+import com.maxrave.domain.data.model.searchResult.songs.SongsResult
+import com.maxrave.domain.data.model.spotify.SpotifyTrack
+
+/**
+ * Ports spotube's `SourcedTrack.rankResults` matching heuristic (spotube's own
+ * Spotify-track -> YouTube-candidate scoring, see `sourced_track.dart`) so a Spotify
+ * track can be matched against a YouTube Music search result with the same fuzziness
+ * spotube uses: no ISRC, no phonetic/edit-distance matching - just title/artist
+ * substring containment plus an "official audio/video" bonus.
+ */
+private val officialMusicRegex = Regex("official (video|audio|music video|lyric video|visualizer)", RegexOption.IGNORE_CASE)
+
+/**
+ * Returns the highest-scoring [SongsResult] for [track] among [candidates], or `null`
+ * if [candidates] is empty. Ties keep the earlier (higher search-rank) candidate.
+ */
+fun rankSongMatches(
+    track: SpotifyTrack,
+    candidates: List<SongsResult>,
+): SongsResult? =
+    candidates.maxByOrNull { candidate -> scoreCandidate(track, candidate) }
+
+private fun scoreCandidate(
+    track: SpotifyTrack,
+    candidate: SongsResult,
+): Int {
+    val title = candidate.title.orEmpty()
+    val candidateArtistNames = candidate.artists?.mapNotNull { it.name }.orEmpty()
+
+    var score = 0
+
+    // +1 if any Spotify artist name case-matches one of the candidate's own artists/channel.
+    if (track.artists.any { artist -> candidateArtistNames.any { it.equals(artist, ignoreCase = true) } }) {
+        score += 1
+    }
+
+    // +1 if the candidate's title contains an artist name.
+    val titleContainsArtist = track.artists.any { artist -> artist.isNotBlank() && title.contains(artist, ignoreCase = true) }
+    if (titleContainsArtist) {
+        score += 1
+    }
+
+    // +3 if the candidate's title contains the track name.
+    val titleContainsTrackName = track.title.isNotBlank() && title.contains(track.title, ignoreCase = true)
+    if (titleContainsTrackName) {
+        score += 3
+    }
+
+    // +1 if the title looks like an official upload.
+    val isOfficial = officialMusicRegex.containsMatchIn(title)
+    if (isOfficial) {
+        score += 1
+    }
+
+    // +2 combo bonus for official + exact track name.
+    if (isOfficial && titleContainsTrackName) {
+        score += 2
+    }
+
+    return score
+}

--- a/domain/src/commonTest/kotlin/com/maxrave/domain/utils/SpotifyTrackMatcherTest.kt
+++ b/domain/src/commonTest/kotlin/com/maxrave/domain/utils/SpotifyTrackMatcherTest.kt
@@ -1,0 +1,83 @@
+package com.maxrave.domain.utils
+
+import com.maxrave.domain.data.model.searchResult.songs.Artist
+import com.maxrave.domain.data.model.searchResult.songs.SongsResult
+import com.maxrave.domain.data.model.spotify.SpotifyTrack
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private fun fakeCandidate(
+    videoId: String,
+    title: String,
+    artistNames: List<String>,
+): SongsResult =
+    SongsResult(
+        album = null,
+        artists = artistNames.map { Artist(id = null, name = it) },
+        category = null,
+        duration = null,
+        durationSeconds = null,
+        feedbackTokens = null,
+        isExplicit = null,
+        resultType = null,
+        thumbnails = null,
+        title = title,
+        videoId = videoId,
+        videoType = null,
+        year = "",
+    )
+
+private fun fakeSpotifyTrack(
+    title: String,
+    artists: List<String>,
+): SpotifyTrack =
+    SpotifyTrack(
+        id = "spotify-track-id",
+        title = title,
+        artists = artists,
+        albumName = null,
+        albumImageUrl = null,
+        durationMs = null,
+        isExplicit = false,
+    )
+
+class SpotifyTrackMatcherTest {
+    @Test
+    fun `returns null when there are no candidates`() {
+        val track = fakeSpotifyTrack("Song", listOf("Artist"))
+        assertNull(rankSongMatches(track, emptyList()))
+    }
+
+    @Test
+    fun `prefers the official upload when the track name matches`() {
+        val track = fakeSpotifyTrack("Blinding Lights", listOf("The Weeknd"))
+        val official = fakeCandidate("v1", "The Weeknd - Blinding Lights (Official Video)", listOf("The Weeknd"))
+        val liveCover = fakeCandidate("v2", "Blinding Lights (Live Cover)", listOf("Some Cover Channel"))
+
+        val best = rankSongMatches(track, listOf(liveCover, official))
+
+        assertEquals("v1", best?.videoId)
+    }
+
+    @Test
+    fun `prefers an artist-matching upload over an unrelated one with a similar title`() {
+        val track = fakeSpotifyTrack("Sunflower", listOf("Post Malone", "Swae Lee"))
+        val correctArtist = fakeCandidate("v1", "Sunflower", listOf("Post Malone"))
+        val wrongArtist = fakeCandidate("v2", "Sunflower", listOf("Random Cover Band"))
+
+        val best = rankSongMatches(track, listOf(wrongArtist, correctArtist))
+
+        assertEquals("v1", best?.videoId)
+    }
+
+    @Test
+    fun `falls back to the only candidate even with a low score`() {
+        val track = fakeSpotifyTrack("Some Obscure Track", listOf("Some Artist"))
+        val onlyCandidate = fakeCandidate("v1", "Totally Unrelated Title", listOf("Unrelated Channel"))
+
+        val best = rankSongMatches(track, listOf(onlyCandidate))
+
+        assertEquals("v1", best?.videoId)
+    }
+}

--- a/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/Spotify.kt
+++ b/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/Spotify.kt
@@ -5,6 +5,8 @@ import com.maxrave.spotify.model.response.spotify.CanvasResponse
 import com.maxrave.spotify.model.response.spotify.ClientTokenResponse
 import com.maxrave.spotify.model.response.spotify.PersonalTokenResponse
 import com.maxrave.spotify.model.response.spotify.SpotifyLyricsResponse
+import com.maxrave.spotify.model.response.spotify.playlist.SpotifyLibraryPlaylistsResponse
+import com.maxrave.spotify.model.response.spotify.playlist.SpotifyPlaylistTracksResponse
 import com.maxrave.spotify.model.response.spotify.search.SpotifySearchResponse
 import io.ktor.client.call.body
 import io.ktor.client.engine.ProxyBuilder
@@ -94,5 +96,34 @@ class Spotify {
         clientToken: String,
     ) = runCatching {
         spotifyClient.getSpotifyCanvas(trackId, token, clientToken).body<CanvasResponse>()
+    }
+
+    /**
+     * Fetch the logged-in user's saved Spotify playlists.
+     */
+    suspend fun getUserPlaylists(
+        authToken: String,
+        clientToken: String,
+        offset: Int = 0,
+        limit: Int = 50,
+    ) = runCatching {
+        spotifyClient
+            .getSpotifyUserPlaylists(authToken, clientToken, offset, limit)
+            .body<SpotifyLibraryPlaylistsResponse>()
+    }
+
+    /**
+     * Fetch the tracks of a single Spotify playlist.
+     */
+    suspend fun getPlaylistTracks(
+        playlistId: String,
+        authToken: String,
+        clientToken: String,
+        offset: Int = 0,
+        limit: Int = 25,
+    ) = runCatching {
+        spotifyClient
+            .getSpotifyPlaylistTracks(playlistId, authToken, clientToken, offset, limit)
+            .body<SpotifyPlaylistTracksResponse>()
     }
 }

--- a/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/SpotifyClient.kt
+++ b/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/SpotifyClient.kt
@@ -210,6 +210,69 @@ class SpotifyClient {
     // {"searchTerm":"trình+hieuthuhai","offset":0,"limit":20,"numberOfTopResults":20,"includeAudiobooks":true,"includePreReleases":false}
     // {"persistedQuery":{"version":1,"sha256Hash":"e4ed1f91a2cc5415befedb85acf8671dc1a4bf3ca1a5b945a6386101a22e28a6"}}
 
+    /**
+     * Fetch the logged-in user's saved playlists ("Your Library" filtered to Playlists).
+     * Persisted query hash / operation reverse-engineered from Spotify's web player
+     * (same one used by third-party unofficial clients, e.g. spotube's Spotify plugin).
+     */
+    suspend fun getSpotifyUserPlaylists(
+        authToken: String,
+        clientToken: String,
+        offset: Int = 0,
+        limit: Int = 50,
+    ) = spotifyClient.get("https://api-partner.spotify.com/pathfinder/v1/query?operationName=libraryV3") {
+        userAgent(USER_AGENT)
+        contentType(ContentType.Application.Json)
+        header("Authorization", "Bearer $authToken")
+        header("Client-Token", clientToken)
+        header(
+            HttpHeaders
+                .AcceptEncoding,
+            "gzip, deflate, br",
+        )
+        val variable =
+            "{\"filters\":[\"Playlists\"],\"order\":null,\"textFilter\":\"\",\"features\":[]," +
+                "\"limit\":$limit,\"offset\":$offset,\"flatten\":true,\"expandedFolders\":[]," +
+                "\"folderUri\":null,\"includeFoldersWhenFlattening\":true}"
+        val sha = "973e511ca44261fda7eebac8b653155e7caee3675abb4fb110cc1b8c78b091c3"
+        parameter("variables", variable)
+        parameter(
+            "extensions",
+            "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"${sha}\"}}",
+        )
+    }
+
+    /**
+     * Fetch the tracks of a single playlist.
+     * Persisted query hash / operation reverse-engineered from Spotify's web player.
+     */
+    suspend fun getSpotifyPlaylistTracks(
+        playlistId: String,
+        authToken: String,
+        clientToken: String,
+        offset: Int = 0,
+        limit: Int = 25,
+    ) = spotifyClient.get("https://api-partner.spotify.com/pathfinder/v1/query?operationName=fetchPlaylist") {
+        userAgent(USER_AGENT)
+        contentType(ContentType.Application.Json)
+        header("Authorization", "Bearer $authToken")
+        header("Client-Token", clientToken)
+        header(
+            HttpHeaders
+                .AcceptEncoding,
+            "gzip, deflate, br",
+        )
+        val variable =
+            "{\"uri\":\"spotify:playlist:$playlistId\",\"offset\":$offset,\"limit\":$limit," +
+                "\"enableWatchFeedEntrypoint\":true}"
+        val sha = "cd2275433b29f7316176e7b5b5e098ae7744724e1a52d63549c76636b3257749"
+        parameter("variables", variable)
+        parameter(
+            "extensions",
+            "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"${sha}\"}}",
+        )
+    }
+
     suspend fun getSpotifyCanvas(
         trackId: String,
         token: String,

--- a/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/model/response/spotify/playlist/SpotifyLibraryPlaylistsResponse.kt
+++ b/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/model/response/spotify/playlist/SpotifyLibraryPlaylistsResponse.kt
@@ -1,0 +1,93 @@
+package com.maxrave.spotify.model.response.spotify.playlist
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Response shape for the "libraryV3" persisted GraphQL query filtered to `["Playlists"]`.
+ * Field names mirror Spotify's internal pathfinder schema (reverse-engineered), not an
+ * official/public contract - keep [kotlinx.serialization.json.Json.ignoreUnknownKeys] on.
+ */
+@Serializable
+data class SpotifyLibraryPlaylistsResponse(
+    val data: Data? = null,
+) {
+    @Serializable
+    data class Data(
+        val me: Me? = null,
+    )
+
+    @Serializable
+    data class Me(
+        val libraryV3: LibraryV3? = null,
+    )
+
+    @Serializable
+    data class LibraryV3(
+        val items: List<LibraryItem>? = null,
+        val totalCount: Int? = null,
+        val pagingInfo: PagingInfo? = null,
+    )
+
+    @Serializable
+    data class PagingInfo(
+        val limit: Int? = null,
+        val offset: Int? = null,
+        val nextOffset: Int? = null,
+    )
+
+    @Serializable
+    data class LibraryItem(
+        val item: ItemWrapper? = null,
+    )
+
+    @Serializable
+    data class ItemWrapper(
+        val data: PlaylistData? = null,
+    )
+
+    @Serializable
+    data class PlaylistData(
+        // "spotify:playlist:<id>"
+        val uri: String? = null,
+        val name: String? = null,
+        val description: String? = null,
+        val images: PlaylistImages? = null,
+        val ownerV2: OwnerV2? = null,
+        val content: PlaylistContentSummary? = null,
+    ) {
+        val id: String?
+            get() = uri?.substringAfterLast(':')
+    }
+
+    @Serializable
+    data class PlaylistImages(
+        val items: List<PlaylistImageItem>? = null,
+    )
+
+    @Serializable
+    data class PlaylistImageItem(
+        val sources: List<ImageSource>? = null,
+    )
+
+    @Serializable
+    data class ImageSource(
+        val url: String? = null,
+        val width: Int? = null,
+        val height: Int? = null,
+    )
+
+    @Serializable
+    data class OwnerV2(
+        val data: OwnerData? = null,
+    )
+
+    @Serializable
+    data class OwnerData(
+        val name: String? = null,
+    )
+
+    @Serializable
+    data class PlaylistContentSummary(
+        val totalCount: Int? = null,
+    )
+}

--- a/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/model/response/spotify/playlist/SpotifyPlaylistTracksResponse.kt
+++ b/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/model/response/spotify/playlist/SpotifyPlaylistTracksResponse.kt
@@ -1,0 +1,112 @@
+package com.maxrave.spotify.model.response.spotify.playlist
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Response shape for the "fetchPlaylist" persisted GraphQL query.
+ * Field names mirror Spotify's internal pathfinder schema (reverse-engineered), not an
+ * official/public contract - keep [kotlinx.serialization.json.Json.ignoreUnknownKeys] on.
+ */
+@Serializable
+data class SpotifyPlaylistTracksResponse(
+    val data: Data? = null,
+) {
+    @Serializable
+    data class Data(
+        val playlistV2: PlaylistV2? = null,
+    )
+
+    @Serializable
+    data class PlaylistV2(
+        val uri: String? = null,
+        val name: String? = null,
+        val images: SpotifyLibraryPlaylistsResponse.PlaylistImages? = null,
+        val ownerV2: SpotifyLibraryPlaylistsResponse.OwnerV2? = null,
+        val content: PlaylistContent? = null,
+    )
+
+    @Serializable
+    data class PlaylistContent(
+        val items: List<PlaylistItem>? = null,
+        val totalCount: Int? = null,
+        val pagingInfo: SpotifyLibraryPlaylistsResponse.PagingInfo? = null,
+    )
+
+    @Serializable
+    data class PlaylistItem(
+        val uid: String? = null,
+        val itemV2: TrackWrapper? = null,
+    )
+
+    @Serializable
+    data class TrackWrapper(
+        val data: TrackData? = null,
+    )
+
+    @Serializable
+    data class TrackData(
+        // "spotify:track:<id>"
+        val uri: String? = null,
+        val id: String? = null,
+        val name: String? = null,
+        val duration: TrackDuration? = null,
+        val trackDuration: TrackDuration? = null,
+        val contentRating: ContentRating? = null,
+        val playcount: String? = null,
+        val albumOfTrack: AlbumOfTrack? = null,
+        val artists: ArtistList? = null,
+        val firstArtist: ArtistList? = null,
+    ) {
+        val spotifyId: String?
+            get() = id ?: uri?.substringAfterLast(':')
+
+        val durationMs: Long?
+            get() = duration?.totalMilliseconds ?: trackDuration?.totalMilliseconds
+
+        val artistNames: List<String>
+            get() =
+                (firstArtist?.items ?: artists?.items)
+                    ?.mapNotNull { it.profile?.name }
+                    .orEmpty()
+
+        val isExplicit: Boolean
+            get() = contentRating?.label?.equals("EXPLICIT", ignoreCase = true) == true
+    }
+
+    @Serializable
+    data class TrackDuration(
+        val totalMilliseconds: Long? = null,
+    )
+
+    @Serializable
+    data class ContentRating(
+        val label: String? = null,
+    )
+
+    @Serializable
+    data class AlbumOfTrack(
+        val uri: String? = null,
+        val name: String? = null,
+        val coverArt: CoverArt? = null,
+    )
+
+    @Serializable
+    data class CoverArt(
+        val sources: List<SpotifyLibraryPlaylistsResponse.ImageSource>? = null,
+    )
+
+    @Serializable
+    data class ArtistList(
+        val items: List<ArtistItem>? = null,
+    )
+
+    @Serializable
+    data class ArtistItem(
+        val profile: ArtistProfile? = null,
+    )
+
+    @Serializable
+    data class ArtistProfile(
+        val name: String? = null,
+    )
+}


### PR DESCRIPTION
- Extend SpotifyClient/Spotify with GraphQL playlist/library calls
- Add SpotifyTokenProvider, deduped out of the lyrics/canvas token refresh
- Add SpotifyLibraryRepository (fetch playlists/tracks, resolve tracks to YouTube Music matches)
- Port spotube's track-matching heuristic (SpotifyTrackMatcher) with tests