### PR TITLE
fix(desktop): sync saved volume onto precached mpv players before load

### DIFF
--- a/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayerAdapter.kt
+++ b/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayerAdapter.kt
@@ -2348,6 +2348,7 @@ class MpvPlayerAdapter(
                                 if (player == null) {
                                     Logger.w(TAG, "Precaching skipped for $idx: could not create mpv player")
                                 } else {
+                                    player.setMasterVolume((internalVolume * 100).toInt())
                                     player.loadFile(buildPlaybackUrl(source), startPaused = true)
                                     precachedPlayers[mediaItem.mediaId] =
                                         PrecachedPlayer(player, mediaItem, source)

--- a/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayerAdapter.kt
+++ b/media/media-jvm/src/main/java/com/simpmusic/media_jvm/mpv/MpvPlayerAdapter.kt
@@ -847,7 +847,14 @@ class MpvPlayerAdapter(
             Logger.w(TAG, "Setting volume to $value")
             internalVolume = value.coerceIn(0f, 1f)
             // mpv volume: 0-100 (100 = unattenuated). Map our 0.0-1.0 to 0-100.
-            currentPlayer?.setMasterVolume((internalVolume * 100).toInt())
+            val percent = (internalVolume * 100).toInt()
+            currentPlayer?.setMasterVolume(percent)
+            // Precached handles are paused and inaudible, but `ao-volume` is not per-handle
+            // everywhere: on Windows every handle lands in the process' default WASAPI session
+            // (mpv passes a NULL AudioSessionGuid), so one ISimpleAudioVolume covers them all.
+            // A sleeping handle still holding an older master would therefore overwrite this
+            // level as soon as its own AUDIO_RECONFIG fires and re-asserts `ao-volume`.
+            precachedPlayers.values.forEach { it.player.setMasterVolume(percent) }
             notifyListeners { onVolumeChanged(internalVolume) }
         }
 


### PR DESCRIPTION
Fixes maxrave-dev/SimpMusic#2319

## Motivation

I've been putting up with this since 1.7.0, and honestly it's a small bug but a really annoying one — having the volume randomly jump to max in the middle of a track breaks my concentration at exactly the moments I need it least. Rather than keep waiting for it to get picked up, I decided to use some AI assistance to dig into the mpv/WASAPI code and track down what was actually happening, even though I'm not that familiar with the audio backend myself. I can't be 100% sure this is the *correct* or complete fix, but I'm hoping it's at least a useful lead for the maintainers, even if the final solution ends up looking different.

## Problem

On Desktop, playback volume randomly jumps to the OS-level maximum a few
seconds into a track, overriding the level set by the in-app slider. It
recurs on every track and is unrelated to crossfade.

## Root cause

Every `MpvPlayer` handle defaults to `masterPercent = 100` until
`setMasterVolume()` is called on it. The precaching path
(`triggerPrecachingInternal`) creates a handle for the next track and loads
it paused, but never applies the user's saved volume to it.

When that paused handle's audio pipeline reconfigures a few seconds into
buffering, mpv fires `AUDIO_RECONFIG`, and `MpvPlayer`'s own handler
re-asserts `ao-volume` from `masterPercent` — still 100 at that point.

On Windows, WASAPI shared mode (the default here) treats `ao-volume` as a
per-session control, not per-stream, and every `MpvPlayer` handle in the
process shares one session. So the precached, inaudible handle's stale
100% volume overwrites the level the currently-playing handle had set,
audible as the OS volume snapping to max — while the app's own slider,
a separate field, still shows the correct value.

## Fix

Apply the current volume to a precached player right after it's created,
before it loads the file, so it can never reach its first
`AUDIO_RECONFIG` with a stale/default value.

## Testing

- Compiled for windows and tested the aplication.
