### PR TITLE
Redact auth headers in request logs (CurlLogger + ktor Logging)

### DIFF
--- a/service/kotlinYtmusicScraper/src/commonMain/kotlin/com/maxrave/kotlinytmusicscraper/Ytmusic.kt
+++ b/service/kotlinYtmusicScraper/src/commonMain/kotlin/com/maxrave/kotlinytmusicscraper/Ytmusic.kt
@@ -166,6 +166,7 @@ class Ytmusic {
             install(Logging) {
                 logger = io.ktor.client.plugins.logging.Logger.DEFAULT
                 level = LogLevel.ALL
+                sanitizeHeader { header -> header.equals("Cookie", ignoreCase = true) || header.equals("Authorization", ignoreCase = true) }
             }
             install(ContentNegotiation) {
                 protobuf()

--- a/service/kotlinYtmusicScraper/src/commonMain/kotlin/com/maxrave/kotlinytmusicscraper/Ytmusic.kt
+++ b/service/kotlinYtmusicScraper/src/commonMain/kotlin/com/maxrave/kotlinytmusicscraper/Ytmusic.kt
@@ -157,6 +157,7 @@ class Ytmusic {
             expectSuccess = true
             install(CurlLogger) {
                 logger = { Logger.d(TAG, it) }
+                redactHeaders = setOf("Cookie", "Authorization")
             }
             install(HttpRedirect) {
                 checkHttpMethod = false

--- a/service/lyricsService/src/commonMain/kotlin/org/simpmusic/lyrics/SimpMusicLyrics.kt
+++ b/service/lyricsService/src/commonMain/kotlin/org/simpmusic/lyrics/SimpMusicLyrics.kt
@@ -49,6 +49,7 @@ class SimpMusicLyrics {
             install(HttpCache)
             install(CurlLogger) {
                 logger = { Logger.d("SimpMusicLyrics", it) }
+                redactHeaders = setOf("Authorization", "X-HMAC", "Cookie")
             }
             install(HttpSend) {
                 maxSendCount = 100

--- a/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/SpotifyClient.kt
+++ b/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/SpotifyClient.kt
@@ -59,6 +59,11 @@ class SpotifyClient {
             install(Logging) {
                 logger = Logger.DEFAULT
                 level = LogLevel.ALL
+                sanitizeHeader { header ->
+                    header.equals("Cookie", ignoreCase = true) ||
+                        header.equals("Authorization", ignoreCase = true) ||
+                        header.equals("Client-Token", ignoreCase = true)
+                }
             }
             install(CurlLogger) {
                 logger = { Logger.DEFAULT.log(it) }

--- a/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/SpotifyClient.kt
+++ b/service/spotify/src/commonMain/kotlin/com/maxrave/spotify/SpotifyClient.kt
@@ -62,6 +62,7 @@ class SpotifyClient {
             }
             install(CurlLogger) {
                 logger = { Logger.DEFAULT.log(it) }
+                redactHeaders = setOf("Cookie", "Authorization", "Client-Token")
             }
             install(HttpSend) {
                 maxSendCount = 100


### PR DESCRIPTION
- Ytmusic, SpotifyClient and SimpMusicLyrics install CurlLogger, and Ytmusic/SpotifyClient
additionally install ktor's built-in Logging plugin at level = LogLevel.ALL right next to it.
Neither had header redaction configured, so every logged request (debug builds / verbose
logging) printed the raw Cookie/Authorization header in full - the user's YouTube session
cookie, Spotify sp_dc cookie and access token, and Apple Music bearer token - through two
separate logging paths at once.

- CurlLoggerConfig.redactHeaders already exists for exactly this but was unused by every caller,
and ktor's Logging plugin has the equivalent sanitizeHeader mechanism, also unused. Wired up
both with the same header set: Cookie + Authorization everywhere, plus Client-Token for Spotify
and X-HMAC for SimpMusicLyrics' signed write endpoints.